### PR TITLE
Properly handle wush error messages

### DIFF
--- a/cmd/coder/shell.go
+++ b/cmd/coder/shell.go
@@ -93,7 +93,7 @@ func (cmd *shellCmd) Run(fl *pflag.FlagSet) {
 
 	exitCode, err := runCommand(envName, command, args)
 	if err != nil {
-		flog.Fatal("run command: %v", err)
+		flog.Fatal("run command: %v Is it online?", err)
 	}
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
Closes #28 

Prints the error returned from wush-lite instead of identifying it as an invalid stream id

Before:
![image](https://user-images.githubusercontent.com/6332295/83300668-07816480-a1be-11ea-8d65-a65df0f1f341.png)

After:
![image](https://user-images.githubusercontent.com/6332295/83300615-ee78b380-a1bd-11ea-8ef8-bb0b0cae74ed.png)
