### PR TITLE
Fix exit code

### DIFF
--- a/cmd/coder/shell.go
+++ b/cmd/coder/shell.go
@@ -63,7 +63,6 @@ func sendResizeEvents(ctx context.Context, termfd int, process wsep.Process) {
 
 		err = process.Resize(ctx, uint16(height), uint16(width))
 		if err != nil {
-			flog.Error("set term size: %v", err)
 			return
 		}
 
@@ -99,7 +98,7 @@ func (cmd *shellCmd) Run(fl *pflag.FlagSet) {
 		os.Exit(exitErr.Code)
 	}
 	if err != nil {
-		flog.Fatal("run command: %v. Is %q online?", err, envName)
+		flog.Fatal("run command: %v", err)
 	}
 }
 
@@ -133,6 +132,7 @@ func runCommand(ctx context.Context, envName string, command string, args []stri
 		Command: command,
 		Args:    args,
 		TTY:     tty,
+		Stdin:   true,
 	})
 	if err != nil {
 		return err
@@ -163,8 +163,8 @@ func runCommand(ctx context.Context, envName string, command string, args []stri
 		}
 	}()
 	err = process.Wait()
-	if xerrors.Is(err, ctx.Err()) {
-		return xerrors.Errorf("network error")
+	if err != nil && xerrors.Is(err, ctx.Err()) {
+		return xerrors.Errorf("network error, is %q online?", envName)
 	}
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module cdr.dev/coder-cli
 go 1.14
 
 require (
-	cdr.dev/wsep v0.0.0-20200612224539-e66f8bb64883
+	cdr.dev/wsep v0.0.0-20200615020153-e2b1c576fc40
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/gorilla/websocket v1.4.1
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,14 @@ cdr.dev/wsep v0.0.0-20200602025116-5cbe721683df h1:9KgAywWKNQMYi3gvu4HyExiuXJhoN
 cdr.dev/wsep v0.0.0-20200602025116-5cbe721683df/go.mod h1:2VKClUml3gfmLez0gBxTJIjSKszpQotc2ZqPdApfK/Y=
 cdr.dev/wsep v0.0.0-20200612224539-e66f8bb64883 h1:nr/trZU6911y9PohrsVaujzJPrtN7bUSX7yfvenYbc0=
 cdr.dev/wsep v0.0.0-20200612224539-e66f8bb64883/go.mod h1:2VKClUml3gfmLez0gBxTJIjSKszpQotc2ZqPdApfK/Y=
+cdr.dev/wsep v0.0.0-20200613153816-ed81c4ad638b h1:cd2Fx+EBMWxWFMdODG/OWRhF9X8OWQ5DnsCEeCfd0Y4=
+cdr.dev/wsep v0.0.0-20200613153816-ed81c4ad638b/go.mod h1:2VKClUml3gfmLez0gBxTJIjSKszpQotc2ZqPdApfK/Y=
+cdr.dev/wsep v0.0.0-20200613225213-3384735ae5e5 h1:x6UJpHOO7mz//OrAdysmQIW+jdXAQ+n35eol5s+O6WU=
+cdr.dev/wsep v0.0.0-20200613225213-3384735ae5e5/go.mod h1:2VKClUml3gfmLez0gBxTJIjSKszpQotc2ZqPdApfK/Y=
+cdr.dev/wsep v0.0.0-20200613231142-71da214c188e h1:ZOQoyb0N07vc9MMet/IQFCpKSObcZZt9o+nPFz7/zNM=
+cdr.dev/wsep v0.0.0-20200613231142-71da214c188e/go.mod h1:2VKClUml3gfmLez0gBxTJIjSKszpQotc2ZqPdApfK/Y=
+cdr.dev/wsep v0.0.0-20200615020153-e2b1c576fc40 h1:f369880iSAZ3cXwvbdc9WIyy3FZ4yanusYZjaVHeis4=
+cdr.dev/wsep v0.0.0-20200615020153-e2b1c576fc40/go.mod h1:2VKClUml3gfmLez0gBxTJIjSKszpQotc2ZqPdApfK/Y=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=


### PR DESCRIPTION
This upgrades `wsep` to the latest version that includes a patch to exit-codes caused by a race condition. This will also fix the issue @wbobeirne had when pulling with `go get -u cdr.dev/coder-cli`. 