### PR TITLE
Sync fails if path leading to remoteDir doesn't already exist

### DIFF
--- a/cmd/coder/sync.go
+++ b/cmd/coder/sync.go
@@ -27,7 +27,7 @@ func (cmd *syncCmd) Spec() cli.CommandSpec {
 }
 
 func (cmd *syncCmd) RegisterFlags(fl *pflag.FlagSet) {
-	fl.BoolVarP(&cmd.init, "init", "i", false, "do inititial transfer and exit")
+	fl.BoolVarP(&cmd.init, "init", "i", false, "do initial transfer and exit")
 }
 
 // See https://lxadm.com/Rsync_exit_codes#List_of_standard_rsync_exit_codes.


### PR DESCRIPTION
I just noticed that setting up sync on a new Environment requires going in first with `coder sh` to create intermediate subdirs of the desired remote path. This patch makes that unnecessary, automatically creating the remote path if not already existent.
