### PR TITLE
login: detect missing protocol in URL

### DIFF
--- a/cmd/coder/login.go
+++ b/cmd/coder/login.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/pkg/browser"
@@ -22,13 +23,13 @@ type loginCmd struct {
 func (cmd loginCmd) Spec() cli.CommandSpec {
 	return cli.CommandSpec{
 		Name:  "login",
-		Usage: "[Coder Enterprise URL]",
+		Usage: "[Coder Enterprise URL eg. http://my.coder.domain/ ]",
 		Desc:  "authenticate this client for future operations",
 	}
 }
 func (cmd loginCmd) Run(fl *pflag.FlagSet) {
 	rawURL := fl.Arg(0)
-	if rawURL == "" {
+	if rawURL == "" || !strings.HasPrefix(rawURL, "http") {
 		exitUsage(fl)
 	}
 


### PR DESCRIPTION
Fixes #53 


### What This Does

Detects a user entering a URL without the protocol field, eg. 'localhost:8080' instead of 'http://localhost:8080' which would result in a malformed login URL, and the stored state using incorrect API paths for all coder-cli operations (eg. sync, sh) which give obscure rsync errors.

Since the cli library dispatches sub-commands to the login.Run() function as non-writable array fl.Arg(), the URL can't be patched up silently to be correct, so instead this patch detects the missing protocol prefix in the URL, and prints out a help usage modified to explain that http[s]:// is required.

