### PR TITLE
Rsync error msgs

### DIFF
--- a/cmd/coder/sync.go
+++ b/cmd/coder/sync.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,7 +32,8 @@ func (cmd *syncCmd) RegisterFlags(fl *pflag.FlagSet) {
 }
 
 // See https://lxadm.com/Rsync_exit_codes#List_of_standard_rsync_exit_codes.
-var NoRsync = errors.New("rsync: exit status 2")
+var IncompatRsync = errors.New("rsync: exit status 2")
+var StreamErrRsync = errors.New("rsync: exit status 12")
 
 func (cmd *syncCmd) Run(fl *pflag.FlagSet) {
 	var (
@@ -79,8 +81,10 @@ func (cmd *syncCmd) Run(fl *pflag.FlagSet) {
 		err = s.Run()
 	}
 
-	if err == NoRsync {
+	if fmt.Sprintf("%v", err) == fmt.Sprintf("%v", IncompatRsync) {
 		flog.Fatal("no compatible rsync present on remote machine")
+	} else if fmt.Sprintf("%v", err) == fmt.Sprintf("%v", StreamErrRsync) {
+		flog.Fatal("error in rsync protocol datastream (no installed remote rsync?)")
 	} else {
 		flog.Fatal("sync: %v", err)
 	}


### PR DESCRIPTION
### What This Does

* Improve checking for rsync errors in initial sync
* Suggest to user what might be wrong (in this case, missing rsync in remote environment)

### Background

While trying out coder-cli on my own dev server, I had used a base ubuntu docker image for my environment. It doesn't install rsync by default, so `coder sync` fails with obscure "rsync: exit status 12".

It took a while for me to realize `rsync` wasn't installed in the environment. We should make coder-cli suggest actions to resolve the issue to the user.

Also, I suspect the existing check for incompatible rsync protocol won't work, as the errors returned from the sync internal package are xerrors vs. the plain error type declared to compare errors against. When I tried adding the equivalent check for error status 12, following the example for exit status 2, the comparison did not work.

I know it's cheezy to compare literal string representations of errors in Go -- so if a better method is suggested I'll use that instead.


### Example 'improved' output if remote environment has no rsync installed

```
$ ./coder sync foo russ-env1:/home/coder/newpath
2020-06-24 11:41:03 INFO	doing initial sync (/home/russtopia/dev/coder-cli/cmd/coder/foo -> /home/coder/newpath)
2020-06-24 11:41:04 FATAL	error in rsync protocol datastream (no installed remote rsync?)
```