### PR TITLE
Verify rsync protocol version match prior to proceeding - Rebased on current master.

### DIFF
--- a/cmd/coder/sync.go
+++ b/cmd/coder/sync.go
@@ -33,7 +33,7 @@ func (cmd *syncCmd) RegisterFlags(fl *pflag.FlagSet) {
 	fl.BoolVarP(&cmd.init, "init", "i", false, "do initial transfer and exit")
 }
 
-// Returns local rsync protocol version as a string.
+// version returns local rsync protocol version as a string.
 func (_ *syncCmd) version() string {
 	cmd := exec.Command("rsync", "--version")
 	out, err := cmd.CombinedOutput()

--- a/cmd/coder/sync.go
+++ b/cmd/coder/sync.go
@@ -99,7 +99,7 @@ func (cmd *syncCmd) Run(fl *pflag.FlagSet) {
 	if rsyncErr != nil {
 		flog.Info("Unable to determine remote rsync version.  Proceeding cautiously.")
 	} else if localVersion != remoteVersion {
-		flog.Fatal(fmt.Sprintf("rsync protocol mismatch. local is %s; remote is %s.", localVersion, remoteVersion))
+		flog.Fatal(fmt.Sprintf("rsync protocol mismatch. %s.", localVersion, rsyncErr))
 	}
 
 	for err == nil || err == sync.ErrRestartSync {

--- a/cmd/coder/sync.go
+++ b/cmd/coder/sync.go
@@ -55,7 +55,12 @@ func (s *syncCmd) version() string {
 		log.Fatal(err)
 	}
 
-	versionString := strings.Split(r.ReadLine(), "protocol version ")
+	firstLine, err := r.ReadString('\n')
+	if err != nil {
+		return ""
+	}
+
+	versionString := strings.Split(firstLine, "protocol version ")
 
 	return versionString[1]
 }
@@ -103,8 +108,8 @@ func (cmd *syncCmd) Run(fl *pflag.FlagSet) {
 		Client:    entClient,
 	}
 
-	localVersion := s.version()
-	remoteVersion, rsyncErr := sync.Version()
+	localVersion := cmd.version()
+	remoteVersion, rsyncErr := s.Version()
 
 	if rsyncErr != nil {
 		flog.Info("Unable to determine remote rsync version.  Proceeding cautiously.")

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -263,7 +263,7 @@ const (
 	maxAcceptableDispatch = time.Millisecond * 50
 )
 
-// Returns remote protocol version as a string.
+// Version returns remote protocol version as a string.
 // Or, an error if one exists.
 func (s Sync) Version() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
@@ -287,9 +287,6 @@ func (s Sync) Version() (string, error) {
 	io.Copy(buf, process.Stdout())
 
 	err = process.Wait()
-	if _, ok := err.(wsep.ExitError); ok {
-		return "", err
-	}
 	if err != nil {
 		return "", err
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -284,11 +284,11 @@ func (s Sync) Version() (string, error) {
 		return "", err
 	}
 	buf := &bytes.Buffer{}
-	go io.Copy(buf, process.Stdout())
+	io.Copy(buf, process.Stdout())
 
 	err = process.Wait()
 	if code, ok := err.(wsep.ExitError); ok {
-		return "", fmt.Errorf("Version heck exit status: %v", code)
+		return "", fmt.Errorf("Version check exit status: %v", code)
 	}
 	if err != nil {
 		return "", fmt.Errorf("Server version mismatch")

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -266,14 +266,14 @@ const (
 // Returns remote protocol version as a string.
 // Or, an error if one exists.
 func (s Sync) Version() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	conn, err := s.Client.DialWsep(ctx, s.Env)
 	if err != nil {
 		return "", err
 	}
 	defer conn.Close(websocket.CloseNormalClosure, "")
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
 
 	execer := wsep.RemoteExecer(conn)
 	process, err := execer.Start(ctx, wsep.Command{

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -287,11 +287,11 @@ func (s Sync) Version() (string, error) {
 	io.Copy(buf, process.Stdout())
 
 	err = process.Wait()
-	if code, ok := err.(wsep.ExitError); ok {
-		return "", fmt.Errorf("Version check exit status: %v", code)
+	if _, ok := err.(wsep.ExitError); ok {
+		return "", err
 	}
 	if err != nil {
-		return "", fmt.Errorf("Server version mismatch")
+		return "", err
 	}
 
 	firstLine, err := buf.ReadString('\n')

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -287,13 +287,18 @@ func (s Sync) Version() (string, error) {
 
 	err = process.Wait()
 	if code, ok := err.(wsep.ExitError); ok {
-		return "", err
+		return "", fmt.Errorf("Version heck exit status: %v", code)
 	}
+	if err != nil {
+		return "", fmt.Errorf("Server version mismatch")
+	}
+
+	firstLine, err := r.ReadString('\n')
 	if err != nil {
 		return "", err
 	}
 
-	versionString := strings.Split(r.ReadLine(), "protocol version ")
+	versionString := strings.Split(firstLine, "protocol version ")
 
 	return versionString[1], nil
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,7 +1,7 @@
 package sync
 
 import (
-	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -283,7 +283,8 @@ func (s Sync) Version() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	r := bufio.NewReader(process.Stdout())
+	buf := &bytes.Buffer{}
+	go io.Copy(buf, process.Stdout())
 
 	err = process.Wait()
 	if code, ok := err.(wsep.ExitError); ok {
@@ -293,7 +294,7 @@ func (s Sync) Version() (string, error) {
 		return "", fmt.Errorf("Server version mismatch")
 	}
 
-	firstLine, err := r.ReadString('\n')
+	firstLine, err := buf.ReadString('\n')
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
`sync.Version()` proceeds with a warning that there may be a version
mismatch if it timesout.

`syncCmd.version` assumes rsync is present in the path.

`wsep` integration is currently unverified.  Verification is next.

Potentially closes #65.