### PR TITLE
Add list users command

### DIFF
--- a/cmd/coder/envs.go
+++ b/cmd/coder/envs.go
@@ -14,7 +14,7 @@ type envsCmd struct {
 func (cmd envsCmd) Spec() cli.CommandSpec {
 	return cli.CommandSpec{
 		Name: "envs",
-		Desc: "get a list of active environment",
+		Desc: "get a list of environments owned by the authenticated user",
 	}
 }
 

--- a/cmd/coder/logout.go
+++ b/cmd/coder/logout.go
@@ -17,7 +17,7 @@ type logoutCmd struct {
 func (cmd logoutCmd) Spec() cli.CommandSpec {
 	return cli.CommandSpec{
 		Name: "logout",
-		Desc: "remote local authentication credentials (if any)",
+		Desc: "remove local authentication credentials (if any)",
 	}
 }
 

--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -42,6 +42,7 @@ func (r *rootCmd) Subcommands() []cli.Command {
 		&urlsCmd{},
 		&versionCmd{},
 		&configSSHCmd{},
+		&usersCmd{},
 	}
 }
 

--- a/cmd/coder/shell.go
+++ b/cmd/coder/shell.go
@@ -27,7 +27,7 @@ func (cmd *shellCmd) Spec() cli.CommandSpec {
 	return cli.CommandSpec{
 		Name:    "sh",
 		Usage:   "<env name> [<command [args...]>]",
-		Desc:    "executes a remote command on the environment\nIf no command is specified, the default shell is opened.",
+		Desc:    "execute a remote command on the environment\nIf no command is specified, the default shell is opened.",
 		RawArgs: true,
 	}
 }

--- a/cmd/coder/users.go
+++ b/cmd/coder/users.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/pflag"
+
+	"go.coder.com/cli"
+	"go.coder.com/flog"
+)
+
+type usersCmd struct {
+}
+
+func (cmd usersCmd) Spec() cli.CommandSpec {
+	return cli.CommandSpec{
+		Name:  "users",
+		Usage: "[subcommand] <flags>",
+		Desc:  "interact with user accounts",
+	}
+}
+
+func (cmd usersCmd) Run(fl *pflag.FlagSet) {
+	exitUsage(fl)
+}
+
+func (cmd *usersCmd) Subcommands() []cli.Command {
+	return []cli.Command{
+		&listCmd{},
+	}
+}
+
+type listCmd struct {
+	outputFmt string
+}
+
+func tabDelimited(data interface{}) string {
+	v := reflect.ValueOf(data)
+	s := &strings.Builder{}
+	for i := 0; i < v.NumField(); i++ {
+		s.WriteString(fmt.Sprintf("%s\t", v.Field(i).Interface()))
+	}
+	return s.String()
+}
+
+func (cmd *listCmd) Run(fl *pflag.FlagSet) {
+	entClient := requireAuth()
+
+	users, err := entClient.Users()
+	if err != nil {
+		flog.Fatal("failed to get users: %v", err)
+	}
+
+	switch cmd.outputFmt {
+	case "human":
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		for _, u := range users {
+			_, err = fmt.Fprintln(w, tabDelimited(u))
+			if err != nil {
+				flog.Fatal("failed to write: %v", err)
+			}
+		}
+		err = w.Flush()
+		if err != nil {
+			flog.Fatal("failed to flush writer: %v", err)
+		}
+	case "json":
+		err = json.NewEncoder(os.Stdout).Encode(users)
+		if err != nil {
+			flog.Fatal("failed to encode users to json: %v", err)
+		}
+	default:
+		exitUsage(fl)
+	}
+
+}
+
+func (cmd *listCmd) RegisterFlags(fl *pflag.FlagSet) {
+	fl.StringVarP(&cmd.outputFmt, "output", "o", "human", "output format (human | json)")
+}
+
+func (cmd *listCmd) Spec() cli.CommandSpec {
+	return cli.CommandSpec{
+		Name:  "ls",
+		Usage: "<flags>",
+		Desc:  "list all users",
+	}
+}

--- a/cmd/coder/version.go
+++ b/cmd/coder/version.go
@@ -15,7 +15,7 @@ func (versionCmd) Spec() cli.CommandSpec {
 	return cli.CommandSpec{
 		Name:  "version",
 		Usage: "",
-		Desc:  "Print the currently installed CLI version",
+		Desc:  "print the currently installed CLI version",
 	}
 }
 

--- a/internal/entclient/me.go
+++ b/internal/entclient/me.go
@@ -1,10 +1,16 @@
 package entclient
 
+import (
+	"time"
+)
+
 // User describes a Coder user account
 type User struct {
-	ID       string `json:"id"`
-	Email    string `json:"email"`
-	Username string `json:"username"`
+	ID        string    `json:"id"`
+	Email     string    `json:"email"`
+	Username  string    `json:"username"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // Me gets the details of the authenticated user

--- a/internal/entclient/users.go
+++ b/internal/entclient/users.go
@@ -1,0 +1,11 @@
+package entclient
+
+// Users gets the list of user accounts
+func (c Client) Users() ([]User, error) {
+	var u []User
+	err := c.requestBody("GET", "/api/users", nil, &u)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}


### PR DESCRIPTION
Related to #76 

## Example Usage
```
$ coder users ls -o json | jq -c '.[] | select( .username == "charlie")' 
{"id":"5e8decf9-563f9fb3a7c02f6e0eafa422","email":"charlie@coder.com","username":"charlie","name":"Charlie","created_at":"2020-04-08T15:25:45.419609Z"}

$ coder users ls -o human | grep charlie
5e8decf9-563f9fb3a7c02f6e0eafa422        charlie@coder.com           charlie                                         Charlie   2020-04-08 15:25:45.419609 +0000 UTC
```