### PR TITLE
Hide sync behind build flag for windows

### DIFF
--- a/ci/steps/build.sh
+++ b/ci/steps/build.sh
@@ -29,8 +29,8 @@ build(){
 # Darwin builds do not work from Linux, so only try to build them from Darwin.
 # See: https://github.com/cdr/coder-cli/issues/20
 if [[ "$(uname)" == "Darwin" ]]; then
-	GOOS=linux build
 	CGO_ENABLED=1 GOOS=darwin build
+	GOOS=linux build
 	GOOS=windows GOARCH=386 build
 	exit 0
 fi
@@ -38,3 +38,4 @@ fi
 echo "Warning: Darwin builds don't work on Linux."
 echo "Please use an OSX machine to build Darwin tars."
 GOOS=linux build
+GOOS=windows GOARCH=386 build

--- a/internal/cmd/sync_unix.go
+++ b/internal/cmd/sync_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/sync_windows.go
+++ b/internal/cmd/sync_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+func makeSyncCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync [local directory] [<env name>:<remote directory>]",
+		Short: "NOT AVAILABLE ON WINDOWS – Establish a one way directory sync to a Coder environment",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return xerrors.Errorf(`"coder sync" is not available on Windows`)
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
Is not strictly required for Windows users, but improves UX. 
Related: #67 