### PR TITLE
Run tcli container on host network

### DIFF
--- a/ci/tcli/tcli.go
+++ b/ci/tcli/tcli.go
@@ -65,6 +65,7 @@ func NewContainerRunner(ctx context.Context, config *ContainerConfig) (*Containe
 	args := []string{
 		"run",
 		"--name", config.Name,
+		"--network", "host",
 		"-it", "-d",
 	}
 	args = append(args, mountArgs(config.BindMounts)...)


### PR DESCRIPTION
This allows the integrations tests to point towards a mocked `cemanager` instances on Coder branch tests.