### PR TITLE
Add --user flag to "secrets" and "envs"

### DIFF
--- a/cmd/coder/auth.go
+++ b/cmd/coder/auth.go
@@ -35,8 +35,10 @@ func newClient() (*entclient.Client, error) {
 		return nil, xerrors.Errorf("url misformatted: %v (try runing coder login)", err)
 	}
 
-	return &entclient.Client{
+	client := &entclient.Client{
 		BaseURL: u,
 		Token:   sessionToken,
-	}, nil
+	}
+
+	return client, nil
 }

--- a/cmd/coder/configssh.go
+++ b/cmd/coder/configssh.go
@@ -83,19 +83,19 @@ func configSSH(filepath *string, remove *bool) func(cmd *cobra.Command, _ []stri
 			return xerrors.New("SSH is disabled or not available for your Coder Enterprise deployment.")
 		}
 
-		me, err := entClient.Me()
+		user, err := entClient.Me(cmd.Context())
 		if err != nil {
 			return xerrors.Errorf("fetch username: %w", err)
 		}
 
-		envs, err := getEnvs(entClient)
+		envs, err := getEnvs(cmd.Context(), entClient, entclient.Me)
 		if err != nil {
 			return err
 		}
 		if len(envs) < 1 {
 			return xerrors.New("no environments found")
 		}
-		newConfig, err := makeNewConfigs(me.Username, envs, startToken, startMessage, endToken)
+		newConfig, err := makeNewConfigs(user.Username, envs, startToken, startMessage, endToken)
 		if err != nil {
 			return xerrors.Errorf("make new ssh configurations: %w", err)
 		}
@@ -127,7 +127,7 @@ var (
 )
 
 func writeSSHKey(ctx context.Context, client *entclient.Client) error {
-	key, err := client.SSHKey()
+	key, err := client.SSHKey(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -19,6 +20,9 @@ var (
 )
 
 func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	if os.Getenv("PPROF") != "" {
 		go func() {
 			log.Println(http.ListenAndServe("localhost:6060", nil))
@@ -49,7 +53,7 @@ func main() {
 		makeURLCmd(),
 		completionCmd,
 	)
-	err = app.Execute()
+	err = app.ExecuteContext(ctx)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/coder/sync.go
+++ b/cmd/coder/sync.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"cdr.dev/coder-cli/internal/entclient"
 	"cdr.dev/coder-cli/internal/sync"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -70,7 +71,7 @@ func makeRunSync(init *bool) func(cmd *cobra.Command, args []string) error {
 			remoteDir = remoteTokens[1]
 		)
 
-		env, err := findEnv(entClient, envName)
+		env, err := findEnv(cmd.Context(), entClient, envName, entclient.Me)
 		if err != nil {
 			return err
 		}

--- a/cmd/coder/users.go
+++ b/cmd/coder/users.go
@@ -33,7 +33,7 @@ func listUsers(outputFmt *string) func(cmd *cobra.Command, args []string) error 
 	return func(cmd *cobra.Command, args []string) error {
 		entClient := requireAuth()
 
-		users, err := entClient.Users()
+		users, err := entClient.Users(cmd.Context())
 		if err != nil {
 			return xerrors.Errorf("get users: %w", err)
 		}

--- a/internal/activity/pusher.go
+++ b/internal/activity/pusher.go
@@ -1,6 +1,7 @@
 package activity
 
 import (
+	"context"
 	"time"
 
 	"cdr.dev/coder-cli/internal/entclient"
@@ -32,12 +33,12 @@ func NewPusher(c *entclient.Client, envID, source string) *Pusher {
 }
 
 // Push pushes activity, abiding by a rate limit
-func (p *Pusher) Push() {
+func (p *Pusher) Push(ctx context.Context) {
 	if !p.rate.Allow() {
 		return
 	}
 
-	err := p.client.PushActivity(p.source, p.envID)
+	err := p.client.PushActivity(ctx, p.source, p.envID)
 	if err != nil {
 		flog.Error("push activity: %s", err.Error())
 	}

--- a/internal/activity/writer.go
+++ b/internal/activity/writer.go
@@ -1,6 +1,9 @@
 package activity
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 type activityWriter struct {
 	p  *Pusher
@@ -9,7 +12,7 @@ type activityWriter struct {
 
 // Write writes to the underlying writer and tracks activity
 func (w *activityWriter) Write(p []byte) (n int, err error) {
-	w.p.Push()
+	w.p.Push(context.Background())
 	return w.wr.Write(p)
 }
 

--- a/internal/entclient/activity.go
+++ b/internal/entclient/activity.go
@@ -1,12 +1,13 @@
 package entclient
 
 import (
+	"context"
 	"net/http"
 )
 
 // PushActivity pushes CLI activity to Coder
-func (c Client) PushActivity(source string, envID string) error {
-	res, err := c.request("POST", "/api/metrics/usage/push", map[string]string{
+func (c Client) PushActivity(ctx context.Context, source string, envID string) error {
+	res, err := c.request(ctx, "POST", "/api/metrics/usage/push", map[string]string{
 		"source":         source,
 		"environment_id": envID,
 	})

--- a/internal/entclient/client.go
+++ b/internal/entclient/client.go
@@ -6,6 +6,9 @@ import (
 	"net/url"
 )
 
+// Me is the route param to access resources of the authenticated user
+const Me = "me"
+
 // Client wraps the Coder HTTP API
 type Client struct {
 	BaseURL *url.URL

--- a/internal/entclient/devurl.go
+++ b/internal/entclient/devurl.go
@@ -1,6 +1,7 @@
 package entclient
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -20,11 +21,10 @@ type delDevURLRequest struct {
 }
 
 // DelDevURL deletes the specified devurl
-func (c Client) DelDevURL(envID, urlID string) error {
-	reqString := "/api/environments/%s/devurls/%s"
-	reqURL := fmt.Sprintf(reqString, envID, urlID)
+func (c Client) DelDevURL(ctx context.Context, envID, urlID string) error {
+	reqURL := fmt.Sprintf("/api/environments/%s/devurls/%s", envID, urlID)
 
-	res, err := c.request("DELETE", reqURL, delDevURLRequest{
+	res, err := c.request(ctx, "DELETE", reqURL, delDevURLRequest{
 		EnvID:    envID,
 		DevURLID: urlID,
 	})
@@ -48,11 +48,10 @@ type createDevURLRequest struct {
 }
 
 // InsertDevURL inserts a new devurl for the authenticated user
-func (c Client) InsertDevURL(envID string, port int, name, access string) error {
-	reqString := "/api/environments/%s/devurls"
-	reqURL := fmt.Sprintf(reqString, envID)
+func (c Client) InsertDevURL(ctx context.Context, envID string, port int, name, access string) error {
+	reqURL := fmt.Sprintf("/api/environments/%s/devurls", envID)
 
-	res, err := c.request("POST", reqURL, createDevURLRequest{
+	res, err := c.request(ctx, "POST", reqURL, createDevURLRequest{
 		EnvID:  envID,
 		Port:   port,
 		Access: access,
@@ -73,11 +72,10 @@ func (c Client) InsertDevURL(envID string, port int, name, access string) error 
 type updateDevURLRequest createDevURLRequest
 
 // UpdateDevURL updates an existing devurl for the authenticated user
-func (c Client) UpdateDevURL(envID, urlID string, port int, name, access string) error {
-	reqString := "/api/environments/%s/devurls/%s"
-	reqURL := fmt.Sprintf(reqString, envID, urlID)
+func (c Client) UpdateDevURL(ctx context.Context, envID, urlID string, port int, name, access string) error {
+	reqURL := fmt.Sprintf("/api/environments/%s/devurls/%s", envID, urlID)
 
-	res, err := c.request("PUT", reqURL, updateDevURLRequest{
+	res, err := c.request(ctx, "PUT", reqURL, updateDevURLRequest{
 		EnvID:  envID,
 		Port:   port,
 		Access: access,

--- a/internal/entclient/env.go
+++ b/internal/entclient/env.go
@@ -34,9 +34,10 @@ type Environment struct {
 }
 
 // Envs gets the list of environments owned by the authenticated user
-func (c Client) Envs(user *User, org Org) ([]Environment, error) {
+func (c Client) Envs(ctx context.Context, user *User, org Org) ([]Environment, error) {
 	var envs []Environment
 	err := c.requestBody(
+		ctx,
 		"GET", "/api/orgs/"+org.ID+"/members/"+user.ID+"/environments",
 		nil,
 		&envs,

--- a/internal/entclient/me.go
+++ b/internal/entclient/me.go
@@ -1,6 +1,7 @@
 package entclient
 
 import (
+	"context"
 	"time"
 )
 
@@ -14,10 +15,10 @@ type User struct {
 	UpdatedAt time.Time `json:"updated_at" tab:"-"`
 }
 
-// Me gets the details of the authenticated user
-func (c Client) Me() (*User, error) {
+// Me gets the details of the authenticated user.
+func (c Client) Me(ctx context.Context) (*User, error) {
 	var u User
-	err := c.requestBody("GET", "/api/users/me", nil, &u)
+	err := c.requestBody(ctx, "GET", "/api/users/me", nil, &u)
 	if err != nil {
 		return nil, err
 	}
@@ -31,9 +32,9 @@ type SSHKey struct {
 }
 
 // SSHKey gets the current SSH kepair of the authenticated user
-func (c Client) SSHKey() (*SSHKey, error) {
+func (c Client) SSHKey(ctx context.Context) (*SSHKey, error) {
 	var key SSHKey
-	err := c.requestBody("GET", "/api/users/me/sshkey", nil, &key)
+	err := c.requestBody(ctx, "GET", "/api/users/me/sshkey", nil, &key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/entclient/org.go
+++ b/internal/entclient/org.go
@@ -1,5 +1,7 @@
 package entclient
 
+import "context"
+
 // Org describes an Organization in Coder
 type Org struct {
 	ID      string `json:"id"`
@@ -8,8 +10,8 @@ type Org struct {
 }
 
 // Orgs gets all Organizations
-func (c Client) Orgs() ([]Org, error) {
+func (c Client) Orgs(ctx context.Context) ([]Org, error) {
 	var os []Org
-	err := c.requestBody("GET", "/api/orgs", nil, &os)
+	err := c.requestBody(ctx, "GET", "/api/orgs", nil, &os)
 	return os, err
 }

--- a/internal/entclient/request.go
+++ b/internal/entclient/request.go
@@ -2,6 +2,7 @@ package entclient
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -9,6 +10,7 @@ import (
 )
 
 func (c Client) request(
+	ctx context.Context,
 	method string, path string,
 	request interface{},
 ) (*http.Response, error) {
@@ -23,7 +25,7 @@ func (c Client) request(
 	if err != nil {
 		return nil, xerrors.Errorf("marshal request: %w", err)
 	}
-	req, err := http.NewRequest(method, c.BaseURL.String()+path, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL.String()+path, bytes.NewReader(body))
 	if err != nil {
 		return nil, xerrors.Errorf("create request: %w", err)
 	}
@@ -31,9 +33,10 @@ func (c Client) request(
 }
 
 func (c Client) requestBody(
+	ctx context.Context,
 	method string, path string, request interface{}, response interface{},
 ) error {
-	resp, err := c.request(method, path, request)
+	resp, err := c.request(ctx, method, path, request)
 	if err != nil {
 		return err
 	}

--- a/internal/entclient/secrets.go
+++ b/internal/entclient/secrets.go
@@ -1,6 +1,7 @@
 package entclient
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -15,21 +16,47 @@ type Secret struct {
 	UpdatedAt   time.Time `json:"updated_at" tab:"-"`
 }
 
+// ReqOptions define api request configuration options
+type ReqOptions struct {
+	// User defines the users whose resources should be targeted
+	User string
+}
+
+// DefaultReqOptions define reasonable defaults for an api request
+var DefaultReqOptions = &ReqOptions{
+	User: Me,
+}
+
 // Secrets gets all secrets owned by the authed user
-func (c *Client) Secrets() ([]Secret, error) {
+func (c *Client) Secrets(ctx context.Context, opts *ReqOptions) ([]Secret, error) {
+	if opts == nil {
+		opts = DefaultReqOptions
+	}
+	user, err := c.UserByEmail(ctx, opts.User)
+	if err != nil {
+		return nil, err
+	}
 	var secrets []Secret
-	err := c.requestBody(http.MethodGet, "/api/users/me/secrets", nil, &secrets)
+	err = c.requestBody(ctx, http.MethodGet, "/api/users/"+user.ID+"/secrets", nil, &secrets)
 	return secrets, err
 }
 
-func (c *Client) secretByID(id string) (*Secret, error) {
+func (c *Client) secretByID(ctx context.Context, id string, opts *ReqOptions) (*Secret, error) {
+	if opts == nil {
+		opts = DefaultReqOptions
+	}
+	user, err := c.UserByEmail(ctx, opts.User)
+	if err != nil {
+		return nil, err
+	}
+
 	var secret Secret
-	err := c.requestBody(http.MethodGet, "/api/users/me/secrets/"+id, nil, &secret)
+	err = c.requestBody(ctx, http.MethodGet, "/api/users/"+user.ID+"/secrets/"+id, nil, &secret)
 	return &secret, err
 }
 
-func (c *Client) secretNameToID(name string) (id string, _ error) {
-	secrets, err := c.Secrets()
+func (c *Client) secretNameToID(ctx context.Context, name string, opts *ReqOptions) (id string, _ error) {
+	secrets, err := c.Secrets(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -42,12 +69,12 @@ func (c *Client) secretNameToID(name string) (id string, _ error) {
 }
 
 // SecretByName gets a secret object by name
-func (c *Client) SecretByName(name string) (*Secret, error) {
-	id, err := c.secretNameToID(name)
+func (c *Client) SecretByName(ctx context.Context, name string, opts *ReqOptions) (*Secret, error) {
+	id, err := c.secretNameToID(ctx, name, opts)
 	if err != nil {
 		return nil, err
 	}
-	return c.secretByID(id)
+	return c.secretByID(ctx, id, opts)
 }
 
 // InsertSecretReq describes the request body for creating a new secret
@@ -58,18 +85,32 @@ type InsertSecretReq struct {
 }
 
 // InsertSecret adds a new secret for the authed user
-func (c *Client) InsertSecret(req InsertSecretReq) error {
+func (c *Client) InsertSecret(ctx context.Context, req InsertSecretReq, opts *ReqOptions) error {
+	if opts == nil {
+		opts = DefaultReqOptions
+	}
+	user, err := c.UserByEmail(ctx, opts.User)
+	if err != nil {
+		return err
+	}
 	var resp interface{}
-	err := c.requestBody(http.MethodPost, "/api/users/me/secrets", req, &resp)
+	err = c.requestBody(ctx, http.MethodPost, "/api/users/"+user.ID+"/secrets", req, &resp)
 	return err
 }
 
 // DeleteSecretByName deletes the authenticated users secret with the given name
-func (c *Client) DeleteSecretByName(name string) error {
-	id, err := c.secretNameToID(name)
+func (c *Client) DeleteSecretByName(ctx context.Context, name string, opts *ReqOptions) error {
+	if opts == nil {
+		opts = DefaultReqOptions
+	}
+	user, err := c.UserByEmail(ctx, opts.User)
 	if err != nil {
 		return err
 	}
-	_, err = c.request(http.MethodDelete, "/api/users/me/secrets/"+id, nil)
+	id, err := c.secretNameToID(ctx, name, opts)
+	if err != nil {
+		return err
+	}
+	_, err = c.request(ctx, http.MethodDelete, "/api/users/"+user.ID+"/secrets/"+id, nil)
 	return err
 }

--- a/internal/entclient/users.go
+++ b/internal/entclient/users.go
@@ -1,11 +1,30 @@
 package entclient
 
+import "context"
+
 // Users gets the list of user accounts
-func (c Client) Users() ([]User, error) {
+func (c Client) Users(ctx context.Context) ([]User, error) {
 	var u []User
-	err := c.requestBody("GET", "/api/users", nil, &u)
+	err := c.requestBody(ctx, "GET", "/api/users", nil, &u)
 	if err != nil {
 		return nil, err
 	}
 	return u, nil
+}
+
+// UserByEmail gets a user by email
+func (c Client) UserByEmail(ctx context.Context, target string) (*User, error) {
+	if target == Me {
+		return c.Me(ctx)
+	}
+	users, err := c.Users(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, u := range users {
+		if u.Email == target {
+			return &u, nil
+		}
+	}
+	return nil, ErrNotFound
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -322,7 +322,7 @@ func (s Sync) Run() error {
 	s.remoteCmd(ctx, "mkdir", "-p", s.RemoteDir)
 
 	ap := activity.NewPusher(s.Client, s.Env.ID, activityName)
-	ap.Push()
+	ap.Push(ctx)
 
 	setConsoleTitle("⏳ syncing project")
 	err = s.initSync()
@@ -382,7 +382,7 @@ func (s Sync) Run() error {
 			}
 			s.workEventGroup(eventGroup)
 			eventGroup = eventGroup[:0]
-			ap.Push()
+			ap.Push(context.TODO())
 		}
 	}
 }


### PR DESCRIPTION
## Samples
Setting a secret value for all users. Of course, were the admin to want a different value for each user, they would need to have some additional way of correlating the email to a secret prior to creating the Coder secret.
```bash
#!/bin/bash

# get all user emails
emails=$(coder users ls --output json | jq -c -r '.[] | .email')

for user in $emails
do
	# create a secret for that user
	coder secrets --user $user create mysql-password --from-literal password123 
done
```

Closes #76 