### PR TITLE
Implement stress test tool

### DIFF
--- a/cmd/stress/main.go
+++ b/cmd/stress/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/cmd"
+	"context"
+	"fmt"
+	"golang.org/x/sync/errgroup"
+	"log"
+	"time"
+)
+
+const (
+	level = 1
+	statSeconds = 30
+	orgID = "default"
+	namePrefix = "stress"
+	imageID = "5f282a6a-2b0fd967178a95ac8078ce31" // master.cdr.dev ubuntu
+	imageTag = "latest"
+	cpuCores = 1
+	memoryGB = 1
+	diskGB = 10
+)
+
+func main() {
+	ctx := context.Background()
+	g, ctx := errgroup.WithContext(ctx)
+	c := cmd.RequireAuth()
+	uid := time.Now().Unix()
+
+	for i := 0; i < level; i++ {
+		i := i //https://golang.org/doc/faq#closures_and_goroutines
+		g.Go(func() error {
+			er := coder.CreateEnvironmentRequest{
+				Name:     fmt.Sprintf("%s-%d-%d", namePrefix, uid, i),
+				ImageID:  imageID,
+				ImageTag: imageTag,
+				CPUCores: cpuCores,
+				MemoryGB: memoryGB,
+				DiskGB:   diskGB,
+			}
+
+			log.Printf("%s: Creating environment\n", er.Name)
+			env, err := c.CreateEnvironment(ctx, orgID, er)
+			if err != nil {
+				return fmt.Errorf("create environment: %w", err)
+			}
+
+			log.Printf("%s: Waiting for environment to be ready\n", er.Name)
+			err = c.WaitForEnvironmentReady(ctx, env.ID)
+			if err != nil {
+				return fmt.Errorf("wait for environment ready: %w", err)
+			}
+
+			log.Printf("%s: Watching environment stats for %d seconds\n", er.Name, statSeconds)
+			err = c.WatchEnvironmentStats(ctx, env.ID, time.Second * statSeconds)
+			if err != nil {
+				return fmt.Errorf("watch environment stats: %w", err)
+			}
+
+			log.Printf("%s: Deleting environment\n", er.Name)
+			err = c.DeleteEnvironment(ctx, env.ID)
+			if err != nil {
+				return fmt.Errorf("delete environment: %w", err)
+			}
+			return nil
+		})
+	}
+	err := g.Wait()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/coder-sdk/image.go
+++ b/coder-sdk/image.go
@@ -1,0 +1,51 @@
+package coder
+
+import (
+	"context"
+	"net/http"
+)
+
+type Image struct {
+	ID              string  `json:"id"`
+	OrganizationID  string  `json:"organization_id"`
+	Repository      string  `json:"repository"`
+	Description     string  `json:"description"`
+	URL             string  `json:"url"` // user-supplied URL for image
+	DefaultCPUCores float32 `json:"default_cpu_cores"`
+	DefaultMemoryGB int     `json:"default_memory_gb"`
+	DefaultDiskGB   int     `json:"default_disk_gb"`
+	Deprecated      bool    `json:"deprecated"`
+}
+
+type NewRegistryRequest struct {
+	FriendlyName string `json:"friendly_name"`
+	Registry     string `json:"registry"`
+	Username     string `json:"username"`
+	Password     string `json:"password"`
+}
+
+type ImportImageRequest struct {
+	// RegistryID is used to import images to existing registries.
+	RegistryID      *string `json:"registry_id"`
+	// NewRegistry is used when adding a new registry.
+	NewRegistry     *NewRegistryRequest `json:"new_registry"`
+	// Repository refers to the image. For example: "codercom/ubuntu".
+	Repository      string  `json:"repository"`
+	Tag             string  `json:"tag"`
+	DefaultCPUCores float32 `json:"default_cpu_cores"`
+	DefaultMemoryGB int     `json:"default_memory_gb"`
+	DefaultDiskGB   int     `json:"default_disk_gb"`
+	Description     string  `json:"description"`
+	URL             string  `json:"url"`
+}
+
+func (c Client) ImportImage(ctx context.Context, orgID string, req ImportImageRequest) (Image, error) {
+	var img Image
+	err := c.requestBody(
+		ctx,
+		http.MethodPost, "/api/orgs/"+orgID+"/images",
+		req,
+		&img,
+	)
+	return img, err
+}

--- a/coder-sdk/users.go
+++ b/coder-sdk/users.go
@@ -73,3 +73,5 @@ func (c Client) UserByEmail(ctx context.Context, email string) (*User, error) {
 	}
 	return nil, ErrNotFound
 }
+
+

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -10,8 +10,8 @@ import (
 	"go.coder.com/flog"
 )
 
-// requireAuth exits the process with a nonzero exit code if the user is not authenticated to make requests
-func requireAuth() *coder.Client {
+// RequireAuth exits the process with a nonzero exit code if the user is not authenticated to make requests
+func RequireAuth() *coder.Client {
 	client, err := newClient()
 	if err != nil {
 		flog.Fatal("%v", err)

--- a/internal/cmd/configssh.go
+++ b/internal/cmd/configssh.go
@@ -85,7 +85,7 @@ func configSSH(configpath *string, remove *bool) func(cmd *cobra.Command, _ []st
 			return nil
 		}
 
-		client := requireAuth()
+		client := RequireAuth()
 
 		sshAvailable := isSSHAvailable(ctx)
 		if !sshAvailable {

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -27,7 +27,7 @@ func makeEnvsCommand() *cobra.Command {
 		Short: "list all environments owned by the active user",
 		Long:  "List all Coder environments owned by the active user.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			entClient := requireAuth()
+			entClient := RequireAuth()
 			envs, err := getEnvs(cmd.Context(), entClient, user)
 			if err != nil {
 				return err

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -79,7 +79,7 @@ coder secrets create aws-credentials --from-file ./credentials.json`,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				client = requireAuth()
+				client = RequireAuth()
 				name   = args[0]
 				value  string
 				err    error
@@ -135,7 +135,7 @@ coder secrets create aws-credentials --from-file ./credentials.json`,
 
 func listSecrets(userEmail *string) func(cmd *cobra.Command, _ []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
-		client := requireAuth()
+		client := RequireAuth()
 		user, err := client.UserByEmail(cmd.Context(), *userEmail)
 		if err != nil {
 			return xerrors.Errorf("get user %q by email: %w", *userEmail, err)
@@ -166,7 +166,7 @@ func listSecrets(userEmail *string) func(cmd *cobra.Command, _ []string) error {
 func makeViewSecret(userEmail *string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		var (
-			client = requireAuth()
+			client = RequireAuth()
 			name   = args[0]
 		)
 		user, err := client.UserByEmail(cmd.Context(), *userEmail)
@@ -190,7 +190,7 @@ func makeViewSecret(userEmail *string) func(cmd *cobra.Command, args []string) e
 func makeRemoveSecrets(userEmail *string) func(c *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		var (
-			client = requireAuth()
+			client = RequireAuth()
 		)
 		user, err := client.UserByEmail(cmd.Context(), *userEmail)
 		if err != nil {

--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -97,7 +97,7 @@ func sendResizeEvents(ctx context.Context, termfd uintptr, process wsep.Process)
 
 func runCommand(ctx context.Context, envName string, command string, args []string) error {
 	var (
-		entClient = requireAuth()
+		entClient = RequireAuth()
 	)
 	env, err := findEnv(ctx, entClient, envName, coder.Me)
 	if err != nil {

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -52,7 +52,7 @@ func makeRunSync(init *bool) func(cmd *cobra.Command, args []string) error {
 			remote = args[1]
 		)
 
-		entClient := requireAuth()
+		entClient := RequireAuth()
 
 		info, err := os.Stat(local)
 		if err != nil {

--- a/internal/cmd/urls.go
+++ b/internal/cmd/urls.go
@@ -153,7 +153,7 @@ func makeCreateDevURL() *cobra.Command {
 			if urlname != "" && !devURLNameValidRx.MatchString(urlname) {
 				return xerrors.New("update devurl: name must be < 64 chars in length, begin with a letter and only contain letters or digits.")
 			}
-			entClient := requireAuth()
+			entClient := RequireAuth()
 
 			env, err := findEnv(cmd.Context(), entClient, envName, coder.Me)
 			if err != nil {
@@ -219,7 +219,7 @@ func removeDevURL(cmd *cobra.Command, args []string) error {
 		return xerrors.Errorf("validate port: %w", err)
 	}
 
-	entClient := requireAuth()
+	entClient := RequireAuth()
 	env, err := findEnv(cmd.Context(), entClient, envName, coder.Me)
 	if err != nil {
 		return err
@@ -246,7 +246,7 @@ func removeDevURL(cmd *cobra.Command, args []string) error {
 
 // urlList returns the list of active devURLs from the cemanager.
 func urlList(ctx context.Context, envName string) ([]DevURL, error) {
-	entClient := requireAuth()
+	entClient := RequireAuth()
 	env, err := findEnv(ctx, entClient, envName, coder.Me)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -31,7 +31,7 @@ coder users ls -o json | jq .[] | jq -r .email`,
 
 func listUsers(outputFmt *string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		entClient := requireAuth()
+		entClient := RequireAuth()
 
 		users, err := entClient.Users(cmd.Context())
 		if err != nil {


### PR DESCRIPTION
The goal of this PR is to have a stress test that can simulate X number of developers creating/starting environments all at once and keeping the dashboard open for Y duration of time.

## What it does
In parallel with X number of concurrent flows it will:
- Use the session token saved from the `coder login`
- Create environment
- Wait for environment ready
- Stream environment stats for X duration
- Delete environment

## Example Output
```
2020/08/20 20:33:19 stress-1597973599-1: Creating environment
2020/08/20 20:33:19 stress-1597973599-0: Creating environment
2020/08/20 20:33:20 stress-1597973599-1: Waiting for environment to be ready
2020/08/20 20:33:20 stress-1597973599-0: Waiting for environment to be ready
2020/08/20 20:34:24 stress-1597973599-1: Watching environment stats for 30 seconds
2020/08/20 20:34:28 stress-1597973599-0: Watching environment stats for 30 seconds
2020/08/20 20:34:57 stress-1597973599-1: Deleting environment
2020/08/20 20:35:01 stress-1597973599-0: Deleting environment
```

## Discussion
- Where is the best place to put this tool? It seems it's out of scope for the coder-cli. Should it be a cmd in the enterprise repo?
- Right now I'm hard coding a lot of values like the image ID and tag, but want to expose these as flags. Is it useful to create the image dynamically for the stress test, or should we just accept an image ID from the cli flag? This question can be applied to the org as well. 

## TBD
- setup stress testing deployment on a separate cluster
- cli flags/args
- listen to `$envID/watch-resource-load` endpoint
- listen to `$envID/ide/api/status` endpoint
- consolidate / cleanup code to be more reusable