### PR TITLE
coder-sdk: remove spurious JSON tag

### DIFF
--- a/coder-sdk/error.go
+++ b/coder-sdk/error.go
@@ -13,7 +13,7 @@ var ErrNotFound = xerrors.Errorf("resource not found")
 
 type apiError struct {
 	Err struct {
-		Msg string `json:"msg,required"`
+		Msg string `json:"msg"`
 	} `json:"error"`
 }
 


### PR DESCRIPTION
The Go `json` struct tag knows nothing of the option `required`.

https://golang.org/pkg/encoding/json/