### PR TITLE
Use "docker cp" instead of bind mounts for tcli integration tests

### DIFF
--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -20,12 +20,14 @@ func run(t *testing.T, container string, execute func(t *testing.T, ctx context.
 		c, err := tcli.NewContainerRunner(ctx, &tcli.ContainerConfig{
 			Image: "codercom/enterprise-dev",
 			Name:  container,
-			BindMounts: map[string]string{
-				binpath: "/bin/coder",
-			},
 		})
 		assert.Success(t, "new run container", err)
 		defer c.Close()
+
+		err = c.CopyFiles(ctx, map[string]string{
+			binpath: "/bin/coder",
+		})
+		assert.Success(t, "copy binary into testing container", err)
 
 		execute(t, ctx, c)
 	})

--- a/ci/tcli/tcli.go
+++ b/ci/tcli/tcli.go
@@ -120,10 +120,10 @@ func (c *ContainerRunner) Run(ctx context.Context, command string) *Assertable {
 }
 
 // RunCmd lifts the given *exec.Cmd into the runtime container
-func (r *ContainerRunner) RunCmd(cmd *exec.Cmd) *Assertable {
+func (c *ContainerRunner) RunCmd(cmd *exec.Cmd) *Assertable {
 	path, _ := exec.LookPath("docker")
 	cmd.Path = path
-	cmd.Args = append([]string{"docker", "exec", "-i", r.name}, cmd.Args...)
+	cmd.Args = append([]string{"docker", "exec", "-i", c.name}, cmd.Args...)
 
 	return &Assertable{
 		cmd:   cmd,


### PR DESCRIPTION
Close #128 