### PR TITLE
Pipe the CLI binary into the test container manually

### DIFF
--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -24,7 +24,7 @@ func run(t *testing.T, container string, execute func(t *testing.T, ctx context.
 			Image: "codercom/enterprise-dev",
 			Name:  container,
 			// use this bind mount just to fix the user perms issue
-			// 
+			//
 			// we'll overwrite this value with the proper binary value later to fix the case
 			// where we're using docker in docker and bind mounts aren't correct
 			BindMounts: map[string]string{
@@ -34,7 +34,7 @@ func run(t *testing.T, container string, execute func(t *testing.T, ctx context.
 		assert.Success(t, "new run container", err)
 		defer c.Close()
 
-		// read the test binary 
+		// read the test binary
 		contents, err := ioutil.ReadFile(binpath)
 		assert.Success(t, "read coder cli binary", err)
 
@@ -43,8 +43,8 @@ func run(t *testing.T, container string, execute func(t *testing.T, ctx context.
 		cmd := exec.CommandContext(ctx, "sh", "-c", "sudo cat - > /bin/coder")
 		cmd.Stdin = bytes.NewReader(contents)
 		c.RunCmd(cmd).Assert(t,
-				tcli.Success(),
-				tcli.StderrEmpty(),
+			tcli.Success(),
+			tcli.StderrEmpty(),
 		)
 
 		execute(t, ctx, c)

--- a/ci/tcli/tcli.go
+++ b/ci/tcli/tcli.go
@@ -88,7 +88,7 @@ func NewContainerRunner(ctx context.Context, config *ContainerConfig) (*Containe
 
 // Close kills and removes the command execution testing container
 func (r *ContainerRunner) Close() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2* time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx,
@@ -113,7 +113,7 @@ func (r *ContainerRunner) Run(ctx context.Context, command string) *Assertable {
 	)
 
 	return &Assertable{
-		cmd:   cmd,
+		cmd: cmd,
 	}
 }
 
@@ -124,7 +124,7 @@ func (r *ContainerRunner) RunCmd(cmd *exec.Cmd) *Assertable {
 	cmd.Args = append([]string{"docker", "exec", "-i", r.name}, cmd.Args...)
 
 	return &Assertable{
-		cmd:   cmd,
+		cmd: cmd,
 	}
 }
 
@@ -137,14 +137,14 @@ func (r *HostRunner) Run(ctx context.Context, command string) *Assertable {
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 
 	return &Assertable{
-		cmd:   cmd,
+		cmd: cmd,
 	}
 }
 
 // RunCmd executes the given *exec.Cmd on the host
 func (r *HostRunner) RunCmd(cmd *exec.Cmd) *Assertable {
 	return &Assertable{
-		cmd:   cmd,
+		cmd: cmd,
 	}
 }
 
@@ -155,7 +155,7 @@ func (r *HostRunner) Close() error {
 
 // Assertable describes an initialized command ready to be run and asserted against
 type Assertable struct {
-	cmd   *exec.Cmd
+	cmd *exec.Cmd
 }
 
 // Assert runs the Assertable and


### PR DESCRIPTION
- use cat and stdin to inject the CLI binary into the container runner

Closes #128 