### PR TITLE
Check for perm error in coder config-ssh

### DIFF
--- a/internal/cmd/configssh.go
+++ b/internal/cmd/configssh.go
@@ -130,7 +130,10 @@ func configSSH(configpath *string, remove *bool) func(cmd *cobra.Command, _ []st
 		}
 		err = writeSSHKey(ctx, client, privateKeyFilepath)
 		if err != nil {
-			fmt.Printf("Your private ssh key already exists at \"%s\"\nYou may need to remove the existing file and re-run this command\n", privateKeyFilepath)
+			if !xerrors.Is(err, os.ErrPermission) {
+				return xerrors.Errorf("write ssh key: %w", err)
+			}
+			fmt.Printf("Your private ssh key already exists at \"%s\"\nYou may need to remove the existing private key file and re-run this command\n\n", privateKeyFilepath)
 		} else {
 			fmt.Printf("Your private ssh key was written to \"%s\"\n", privateKeyFilepath)
 		}


### PR DESCRIPTION
Exit with an error if the failure to write the SSH private key file is anything except for an `os.ErrPermission`