### PR TITLE
Add resource top flags for filtering and sorting

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -27,7 +27,7 @@ func Make() *cobra.Command {
 		envsCommand(),
 		makeSyncCmd(),
 		makeURLCmd(),
-		makeResourceCmd(),
+		resourceCmd(),
 		completionCmd,
 		genDocs(app),
 	)


### PR DESCRIPTION
This PR implements the following flags for `coder resources top`

```
      --org string       filter by the name of an organization
      --show-empty       show groups with zero active environments
      --sort-by string   field to sort aggregate groups and environments by (cpu|memory) (default "cpu")
      --user string      filter by a user email
```