### PR TITLE
Add new rich error messages

### DIFF
--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -9,10 +9,9 @@ import (
 	"os"
 	"runtime"
 
+	"cdr.dev/coder-cli/internal/clog"
 	"cdr.dev/coder-cli/internal/cmd"
 	"cdr.dev/coder-cli/internal/x/xterminal"
-
-	"go.coder.com/flog"
 )
 
 // Using a global for the version so it can be set at build time using ldflags.
@@ -31,7 +30,8 @@ func main() {
 
 	stdoutState, err := xterminal.MakeOutputRaw(os.Stdout.Fd())
 	if err != nil {
-		flog.Fatal("set output to raw: %s", err)
+		clog.Log(clog.Fatal(fmt.Sprintf("set output to raw: %s", err)))
+		os.Exit(1)
 	}
 	defer func() {
 		// Best effort. Would result in broken terminal on window but nothing we can do about it.
@@ -42,6 +42,7 @@ func main() {
 	app.Version = fmt.Sprintf("%s %s %s/%s", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
 	if err := app.ExecuteContext(ctx); err != nil {
-		flog.Fatal("%v", err)
+		clog.Log(err)
+		os.Exit(1)
 	}
 }

--- a/coder-sdk/error.go
+++ b/coder-sdk/error.go
@@ -12,8 +12,8 @@ import (
 // ErrNotFound describes an error case in which the requested resource could not be found
 var ErrNotFound = xerrors.Errorf("resource not found")
 
-// apiError is the expected payload format for our errors.
-type apiError struct {
+// APIError is the expected payload format for our errors.
+type APIError struct {
 	Err struct {
 		Msg string `json:"msg"`
 	} `json:"error"`
@@ -30,7 +30,7 @@ func (e *HTTPError) Error() string {
 		return fmt.Sprintf("dump response: %+v", err)
 	}
 
-	var msg apiError
+	var msg APIError
 	// Try to decode the payload as an error, if it fails or if there is no error message,
 	// return the response URL with the dump.
 	if err := json.NewDecoder(e.Response.Body).Decode(&msg); err != nil || msg.Err.Msg == "" {
@@ -38,7 +38,7 @@ func (e *HTTPError) Error() string {
 	}
 
 	// If the payload was a in the expected error format with a message, include it.
-	return fmt.Sprintf("%s\n%s%s", e.Response.Request.URL, dump, msg.Err.Msg)
+	return msg.Err.Msg
 }
 
 func bodyError(resp *http.Response) error {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/rjeczalik/notify v0.9.2
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
-	go.coder.com/flog v0.0.0-20190906214207-47dd47ea0512
 	golang.org/x/crypto v0.0.0-20200422194213-44a606286825
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13

--- a/internal/activity/pusher.go
+++ b/internal/activity/pusher.go
@@ -2,13 +2,13 @@ package activity
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"golang.org/x/time/rate"
 
 	"cdr.dev/coder-cli/coder-sdk"
-
-	"go.coder.com/flog"
+	"cdr.dev/coder-cli/internal/clog"
 )
 
 const pushInterval = time.Minute
@@ -42,6 +42,6 @@ func (p *Pusher) Push(ctx context.Context) {
 	}
 
 	if err := p.client.PushActivity(ctx, p.source, p.envID); err != nil {
-		flog.Error("push activity: %s", err)
+		clog.Log(clog.Error(fmt.Sprintf("push activity: %s", err)))
 	}
 }

--- a/internal/clog/error.go
+++ b/internal/clog/error.go
@@ -1,0 +1,131 @@
+package clog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"golang.org/x/xerrors"
+)
+
+// CLIMessage provides a human-readable message for CLI errors and messages.
+type CLIMessage struct {
+	Level  string
+	Color  color.Attribute
+	Header string
+	Lines  []string
+}
+
+// CLIError wraps a CLIMessage and allows consumers to treat it as a normal error.
+type CLIError struct {
+	CLIMessage
+	error
+}
+
+// String formats the CLI message for consumption by a human.
+func (m CLIMessage) String() string {
+	var str strings.Builder
+	str.WriteString(fmt.Sprintf("%s: %s\n",
+		color.New(m.Color).Sprint(m.Level),
+		color.New(color.Bold).Sprint(m.Header)),
+	)
+	for _, line := range m.Lines {
+		str.WriteString(fmt.Sprintf("  %s %s\n", color.New(m.Color).Sprint("|"), line))
+	}
+	return str.String()
+}
+
+// Log logs the given error to stderr, defaulting to "fatal" if the error is not a CLIError.
+// If the error is a CLIError, the plain error chain is ignored and the CLIError
+// is logged on its own.
+func Log(err error) {
+	var cliErr CLIError
+	if !xerrors.As(err, &cliErr) {
+		cliErr = Fatal(err.Error())
+	}
+	fmt.Fprintln(os.Stderr, cliErr.String())
+}
+
+// LogInfo prints the given info message to stderr.
+func LogInfo(header string, lines ...string) {
+	fmt.Fprint(os.Stderr, CLIMessage{
+		Level:  "info",
+		Color:  color.FgBlue,
+		Header: header,
+		Lines:  lines,
+	}.String())
+}
+
+// LogSuccess prints the given info message to stderr.
+func LogSuccess(header string, lines ...string) {
+	fmt.Fprint(os.Stderr, CLIMessage{
+		Level:  "success",
+		Color:  color.FgGreen,
+		Header: header,
+		Lines:  lines,
+	}.String())
+}
+
+// Warn creates an error with the level "warning".
+func Warn(header string, lines ...string) CLIError {
+	return CLIError{
+		CLIMessage: CLIMessage{
+			Color:  color.FgYellow,
+			Level:  "warning",
+			Header: header,
+			Lines:  lines,
+		},
+		error: errors.New(header),
+	}
+}
+
+// Error creates an error with the level "error".
+func Error(header string, lines ...string) CLIError {
+	return CLIError{
+		CLIMessage: CLIMessage{
+			Color:  color.FgRed,
+			Level:  "error",
+			Header: header,
+			Lines:  lines,
+		},
+		error: errors.New(header),
+	}
+}
+
+// Fatal creates an error with the level "fatal".
+func Fatal(header string, lines ...string) CLIError {
+	return CLIError{
+		CLIMessage: CLIMessage{
+			Color:  color.FgRed,
+			Level:  "fatal",
+			Header: header,
+			Lines:  lines,
+		},
+		error: errors.New(header),
+	}
+}
+
+// Bold provides a convenience wrapper around color.New for brevity when logging.
+func Bold(a string) string {
+	return color.New(color.Bold).Sprint(a)
+}
+
+// Tip formats according to the given format specifier and prepends a bolded "tip: " header.
+func Tip(format string, a ...interface{}) string {
+	return fmt.Sprintf("%s %s", Bold("tip:"), fmt.Sprintf(format, a...))
+}
+
+// Hint formats according to the given format specifier and prepends a bolded "hint: " header.
+func Hint(format string, a ...interface{}) string {
+	return fmt.Sprintf("%s %s", Bold("hint:"), fmt.Sprintf(format, a...))
+}
+
+// Cause formats according to the given format specifier and prepends a bolded "cause: " header.
+func Cause(format string, a ...interface{}) string {
+	return fmt.Sprintf("%s %s", Bold("cause:"), fmt.Sprintf(format, a...))
+}
+
+// BlankLine is an empty string meant to be used in CLIMessage and CLIError construction.
+const BlankLine = ""

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -8,10 +8,14 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/clog"
 	"cdr.dev/coder-cli/internal/config"
 )
 
-var errNeedLogin = xerrors.New("failed to read session credentials: did you run \"coder login\"?")
+var errNeedLogin = clog.Fatal(
+	"failed to read session credentials",
+	clog.Hint(`did you run "coder login [https://coder.domain.com]"?`),
+)
 
 func newClient() (*coder.Client, error) {
 	sessionToken, err := config.Session.Read()

--- a/internal/cmd/ceapi.go
+++ b/internal/cmd/ceapi.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/clog"
 	"golang.org/x/xerrors"
 )
 
@@ -73,10 +74,12 @@ func findEnv(ctx context.Context, client *coder.Client, envName, userEmail strin
 		found = append(found, env.Name)
 	}
 
-	return nil, notFoundButDidFind{
-		needle:   envName,
-		haystack: found,
-	}
+	return nil, clog.Fatal(
+		"failed to find environment",
+		fmt.Sprintf("environment %q not found in %q", envName, found),
+		clog.BlankLine,
+		clog.Tip("run \"coder envs ls\" to view your environments"),
+	)
 }
 
 type notFoundButDidFind struct {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/clog"
 	"cdr.dev/coder-cli/internal/config"
 	"cdr.dev/coder-cli/internal/loginsrv"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
-
-	"go.coder.com/flog"
 )
 
 func makeLoginCmd() *cobra.Command {
@@ -140,7 +139,7 @@ func login(cmd *cobra.Command, envURL *url.URL, urlCfg, sessionCfg config.File) 
 		return xerrors.Errorf("store config: %w", err)
 	}
 
-	flog.Success("Logged in.")
+	clog.LogSuccess("logged in")
 
 	return nil
 }

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -3,11 +3,10 @@ package cmd
 import (
 	"os"
 
+	"cdr.dev/coder-cli/internal/clog"
 	"cdr.dev/coder-cli/internal/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
-
-	"go.coder.com/flog"
 )
 
 func makeLogoutCmd() *cobra.Command {
@@ -22,11 +21,11 @@ func logout(_ *cobra.Command, _ []string) error {
 	err := config.Session.Delete()
 	if err != nil {
 		if os.IsNotExist(err) {
-			flog.Info("no active session")
+			clog.LogInfo("no active session")
 			return nil
 		}
 		return xerrors.Errorf("delete session: %w", err)
 	}
-	flog.Success("logged out")
+	clog.LogSuccess("logged out")
 	return nil
 }

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/clog"
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"go.coder.com/flog"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/xerrors"
 )
@@ -56,7 +56,10 @@ coder envs rebuild backend-env --force`,
 					return err
 				}
 			} else {
-				flog.Info("Use \"coder envs watch-build %s\" to follow the build logs", env.Name)
+				clog.LogSuccess(
+					"successfully started rebuild",
+					clog.Tip("run \"coder envs watch-build %s\" to follow the build logs", env.Name),
+				)
 			}
 			return nil
 		},

--- a/internal/cmd/resourcemanager.go
+++ b/internal/cmd/resourcemanager.go
@@ -8,8 +8,8 @@ import (
 	"text/tabwriter"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/clog"
 	"github.com/spf13/cobra"
-	"go.coder.com/flog"
 	"golang.org/x/xerrors"
 )
 
@@ -212,8 +212,10 @@ func printResourceTop(writer io.Writer, groups []groupable, labeler envLabeler, 
 		_, _ = fmt.Fprint(tabwriter, "\n")
 	}
 	if len(userResources) == 0 {
-		flog.Info("No groups for the given filters exist with active environments.")
-		flog.Info("Use \"--show-empty\" to see groups with no resources.")
+		clog.LogInfo(
+			"no groups for the given filters exist with active environments",
+			clog.Tip("run \"--show-empty\" to see groups with no resources."),
+		)
 	}
 	return nil
 }

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -10,9 +10,8 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/clog"
 	"cdr.dev/coder-cli/internal/x/xtabwriter"
-
-	"go.coder.com/flog"
 )
 
 func makeSecretsCmd() *cobra.Command {
@@ -154,7 +153,7 @@ func listSecrets(userEmail *string) func(cmd *cobra.Command, _ []string) error {
 		}
 
 		if len(secrets) < 1 {
-			flog.Info("No secrets found")
+			clog.LogInfo("no secrets found")
 			return nil
 		}
 
@@ -212,10 +211,12 @@ func makeRemoveSecrets(userEmail *string) func(c *cobra.Command, args []string) 
 		for _, n := range args {
 			err := client.DeleteSecretByName(cmd.Context(), n, user.ID)
 			if err != nil {
-				flog.Error("failed to delete secret %q: %v", n, err)
+				clog.Log(clog.Error(
+					fmt.Sprintf("failed to delete secret %q: %v", n, err),
+				))
 				errorSeen = true
 			} else {
-				flog.Success("successfully deleted secret %q", n)
+				clog.LogSuccess("successfully deleted secret: %q", n)
 			}
 		}
 		if errorSeen {

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -9,11 +9,10 @@ import (
 	"strings"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/clog"
 	"cdr.dev/coder-cli/internal/sync"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
-
-	"go.coder.com/flog"
 )
 
 func makeSyncCmd() *cobra.Command {
@@ -96,7 +95,7 @@ func makeRunSync(init *bool) func(cmd *cobra.Command, args []string) error {
 		remoteVersion, rsyncErr := s.Version()
 
 		if rsyncErr != nil {
-			flog.Info("Unable to determine remote rsync version.  Proceeding cautiously.")
+			clog.LogInfo("unable to determine remote rsync version: proceeding cautiously")
 		} else if localVersion != remoteVersion {
 			return xerrors.Errorf("rsync protocol mismatch: local = %s, remote = %s", localVersion, remoteVersion)
 		}

--- a/internal/cmd/urls.go
+++ b/internal/cmd/urls.go
@@ -14,9 +14,8 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/clog"
 	"cdr.dev/coder-cli/internal/x/xtabwriter"
-
-	"go.coder.com/flog"
 )
 
 func makeURLCmd() *cobra.Command {
@@ -70,7 +69,7 @@ var urlAccessLevel = map[string]string{
 func validatePort(port string) (int, error) {
 	p, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
-		flog.Error("Invalid port")
+		clog.Log(clog.Error("invalid port"))
 		return 0, err
 	}
 	if p < 1 {
@@ -83,7 +82,7 @@ func validatePort(port string) (int, error) {
 func accessLevelIsValid(level string) bool {
 	_, ok := urlAccessLevel[level]
 	if !ok {
-		flog.Error("Invalid access level")
+		clog.Log(clog.Error("invalid access level"))
 	}
 	return ok
 }
@@ -101,7 +100,7 @@ func makeListDevURLs(outputFmt *string) func(cmd *cobra.Command, args []string) 
 		switch *outputFmt {
 		case "human":
 			if len(devURLs) < 1 {
-				flog.Info("No devURLs found for environment %q", envName)
+				clog.LogInfo(fmt.Sprintf("no devURLs found for environment %q", envName))
 				return nil
 			}
 			err := xtabwriter.WriteTable(len(devURLs), func(i int) interface{} {
@@ -168,13 +167,13 @@ func makeCreateDevURL() *cobra.Command {
 
 			urlID, found := devURLID(portNum, urls)
 			if found {
-				flog.Info("Updating devurl for port %v", port)
+				clog.LogInfo(fmt.Sprintf("updating devurl for port %v", port))
 				err := client.UpdateDevURL(cmd.Context(), env.ID, urlID, portNum, urlname, access)
 				if err != nil {
 					return xerrors.Errorf("update DevURL: %w", err)
 				}
 			} else {
-				flog.Info("Adding devurl for port %v", port)
+				clog.LogInfo(fmt.Sprintf("Adding devurl for port %v", port))
 				err := client.InsertDevURL(cmd.Context(), env.ID, portNum, urlname, access)
 				if err != nil {
 					return xerrors.Errorf("insert DevURL: %w", err)
@@ -236,7 +235,7 @@ func removeDevURL(cmd *cobra.Command, args []string) error {
 
 	urlID, found := devURLID(portNum, urls)
 	if found {
-		flog.Info("Deleting devurl for port %v", port)
+		clog.LogInfo(fmt.Sprintf("deleting devurl for port %v", port))
 	} else {
 		return xerrors.Errorf("No devurl found for port %v", port)
 	}

--- a/internal/sync/eventcache.go
+++ b/internal/sync/eventcache.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/rjeczalik/notify"
-
-	"go.coder.com/flog"
 )
 
 type timedEvent struct {
@@ -17,18 +15,14 @@ type timedEvent struct {
 type eventCache map[string]timedEvent
 
 func (cache eventCache) Add(ev timedEvent) {
-	log := flog.New()
-	log.Prefix = ev.Path() + ": "
 	lastEvent, ok := cache[ev.Path()]
 	if ok {
 		switch {
 		// If the file was quickly created and then destroyed, pretend nothing ever happened.
 		case lastEvent.Event() == notify.Create && ev.Event() == notify.Remove:
 			delete(cache, ev.Path())
-			log.Info("ignored Create then Remove")
 			return
 		}
-		log.Info("replaced %s with %s", lastEvent.Event(), ev.Event())
 	}
 	// Only let the latest event for a path have action.
 	cache[ev.Path()] = ev


### PR DESCRIPTION
Inspired by the `cargo` message formatting.

<img width="638" alt="Screen Shot 2020-10-21 at 1 08 31 PM" src="https://user-images.githubusercontent.com/7585078/96760412-86aa4b80-139e-11eb-9ed5-c1ab065acce8.png">

<img width="671" alt="Screen Shot 2020-10-21 at 1 34 53 AM" src="https://user-images.githubusercontent.com/7585078/96681937-a9f0de80-133d-11eb-9a7f-7710303caa13.png">
<img width="636" alt="Screen Shot 2020-10-21 at 1 13 48 PM" src="https://user-images.githubusercontent.com/7585078/96763593-44cdd500-139f-11eb-9e65-bfbc05591b95.png">
