### PR TITLE
Change coder create | edit envs image flag to take image name and source defaults from image

### DIFF
--- a/ci/integration/envs_test.go
+++ b/ci/integration/envs_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // From Coder organization images
-const ubuntuImgID = "5f443b16-30652892427b955601330fa5"
+// const ubuntuImgID = "5f443b16-30652892427b955601330fa5"
 
 func TestEnvsCLI(t *testing.T) {
 	t.Parallel()
@@ -37,6 +37,18 @@ func TestEnvsCLI(t *testing.T) {
 			tcli.StderrEmpty(),
 		)
 
+		// Image unset.
+		c.Run(ctx, "coder envs create test-env").Assert(t,
+			tcli.StderrMatches(regexp.QuoteMeta("fatal: required flag(s) \"image\" not set")),
+			tcli.Error(),
+		)
+
+		// Image not imported.
+		c.Run(ctx, "coder envs create test-env --image doesntmatter").Assert(t,
+			tcli.StderrMatches(regexp.QuoteMeta("fatal: image not found - did you forget to import this image?")),
+			tcli.Error(),
+		)
+
 		// TODO(Faris) : uncomment this when we can safely purge the environments
 		// the integrations tests would create in the sidecar
 		// Successfully create environment.
@@ -46,12 +58,6 @@ func TestEnvsCLI(t *testing.T) {
 		// 	tcli.StderrMatches(regexp.QuoteMeta("Successfully created environment \"test-ubuntu\"")),
 		// )
 
-		// Invalid environment name should fail.
-		c.Run(ctx, "coder envs create --image "+ubuntuImgID+" this-IS-an-invalid-EnvironmentName").Assert(t,
-			tcli.Error(),
-			tcli.StderrMatches(regexp.QuoteMeta("environment name must conform to regex ^[a-z0-9]([a-z0-9-]+)?")),
-		)
-
 		// TODO(Faris) : uncomment this when we can safely purge the environments
 		// the integrations tests would create in the sidecar
 		// Successfully provision environment with fractional resource amounts
@@ -59,11 +65,5 @@ func TestEnvsCLI(t *testing.T) {
 		// 	tcli.Success(),
 		// 	tcli.StderrMatches(regexp.QuoteMeta("Successfully created environment \"non-whole-resource-amounts\"")),
 		// )
-
-		// Image does not exist should fail.
-		c.Run(ctx, "coder envs create --image does-not-exist env-will-not-be-created").Assert(t,
-			tcli.Error(),
-			tcli.StderrMatches(regexp.QuoteMeta("does not exist")),
-		)
 	})
 }

--- a/coder-sdk/image.go
+++ b/coder-sdk/image.go
@@ -13,7 +13,7 @@ type Image struct {
 	Description     string  `json:"description"`
 	URL             string  `json:"url"` // User-supplied URL for image.
 	DefaultCPUCores float32 `json:"default_cpu_cores"`
-	DefaultMemoryGB int     `json:"default_memory_gb"`
+	DefaultMemoryGB float32 `json:"default_memory_gb"`
 	DefaultDiskGB   int     `json:"default_disk_gb"`
 	Deprecated      bool    `json:"deprecated"`
 }
@@ -46,4 +46,13 @@ func (c Client) ImportImage(ctx context.Context, orgID string, req ImportImageRe
 		return nil, err
 	}
 	return &img, nil
+}
+
+// OrganizationImages returns all of the images imported for orgID.
+func (c Client) OrganizationImages(ctx context.Context, orgID string) ([]Image, error) {
+	var imgs []Image
+	if err := c.requestBody(ctx, http.MethodGet, "/api/orgs/"+orgID+"/images", nil, &imgs); err != nil {
+		return nil, err
+	}
+	return imgs, nil
 }

--- a/internal/clog/error.go
+++ b/internal/clog/error.go
@@ -68,6 +68,16 @@ func LogSuccess(header string, lines ...string) {
 	}.String())
 }
 
+// LogWarn prints the given warn message to stderr.
+func LogWarn(header string, lines ...string) {
+	fmt.Fprint(os.Stderr, CLIMessage{
+		Level:  "warning",
+		Color:  color.FgYellow,
+		Header: header,
+		Lines:  lines,
+	}.String())
+}
+
 // Warn creates an error with the level "warning".
 func Warn(header string, lines ...string) CLIError {
 	return CLIError{

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,20 +10,14 @@ import (
 	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/coder-cli/internal/clog"
 	"cdr.dev/coder-cli/internal/x/xtabwriter"
+
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 )
 
-const (
-	defaultOrg              = "default"
-	defaultImgTag           = "latest"
-	defaultCPUCores float32 = 1
-	defaultMemGB    float32 = 1
-	defaultDiskGB           = 10
-	defaultGPUs             = 0
-)
+const defaultImgTag = "latest"
 
 func envsCommand() *cobra.Command {
 	var user string
@@ -39,7 +34,7 @@ func envsCommand() *cobra.Command {
 		rmEnvsCommand(&user),
 		watchBuildLogCommand(),
 		rebuildEnvCommand(),
-		createEnvCommand(),
+		createEnvCommand(&user),
 		editEnvCommand(&user),
 	)
 	return cmd
@@ -147,7 +142,7 @@ coder envs --user charlie@coder.com ls -o json \
 	}
 }
 
-func createEnvCommand() *cobra.Command {
+func createEnvCommand(user *string) *cobra.Command {
 	var (
 		org    string
 		img    string
@@ -169,27 +164,61 @@ coder envs create --image 5f443b16-30652892427b955601330fa5 my-env-name
 coder envs create --cpu 4 --disk 100 --memory 8 --image 5f443b16-30652892427b955601330fa5 my-env-name`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if img == "" {
-				return xerrors.New("image id unset")
+				return xerrors.New("image unset")
 			}
-			// ExactArgs(1) ensures our name value can't panic on an out of bounds.
-			createReq := &coder.CreateEnvironmentRequest{
-				Name:     args[0],
-				ImageID:  img,
-				ImageTag: tag,
-			}
-			// We're explicitly ignoring errors for these because all of these flags
-			// have a non-zero-value default value set already.
-			createReq.CPUCores, _ = cmd.Flags().GetFloat32("cpu")
-			createReq.MemoryGB, _ = cmd.Flags().GetFloat32("memory")
-			createReq.DiskGB, _ = cmd.Flags().GetInt("disk")
-			createReq.GPUs, _ = cmd.Flags().GetInt("gpus")
 
 			client, err := newClient()
 			if err != nil {
 				return err
 			}
 
-			env, err := client.CreateEnvironment(cmd.Context(), org, *createReq)
+			multiOrgMember, err := isMultiOrgMember(cmd.Context(), client, *user)
+			if err != nil {
+				return err
+			}
+
+			if multiOrgMember && org == "" {
+				return xerrors.New("org is required for multi-org members")
+			}
+
+			importedImg, err := findImg(cmd.Context(),
+				findImgConf{
+					client:  client,
+					email:   *user,
+					imgName: img,
+					orgName: org,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			// ExactArgs(1) ensures our name value can't panic on an out of bounds.
+			createReq := &coder.CreateEnvironmentRequest{
+				Name:     args[0],
+				ImageID:  importedImg.ID,
+				ImageTag: tag,
+			}
+			// We're explicitly ignoring errors for these because all we
+			// need to now is if the numeric type is 0 or not.
+			createReq.CPUCores, _ = cmd.Flags().GetFloat32("cpu")
+			createReq.MemoryGB, _ = cmd.Flags().GetFloat32("memory")
+			createReq.DiskGB, _ = cmd.Flags().GetInt("disk")
+			createReq.GPUs, _ = cmd.Flags().GetInt("gpus")
+
+			// if any of these defaulted to their zero value we provision
+			// the create request with the imported image defaults instead.
+			if createReq.CPUCores == 0 {
+				createReq.CPUCores = importedImg.DefaultCPUCores
+			}
+			if createReq.MemoryGB == 0 {
+				createReq.MemoryGB = importedImg.DefaultMemoryGB
+			}
+			if createReq.DiskGB == 0 {
+				createReq.DiskGB = importedImg.DefaultDiskGB
+			}
+
+			env, err := client.CreateEnvironment(cmd.Context(), importedImg.OrganizationID, *createReq)
 			if err != nil {
 				return xerrors.Errorf("create environment: %w", err)
 			}
@@ -209,13 +238,13 @@ coder envs create --cpu 4 --disk 100 --memory 8 --image 5f443b16-30652892427b955
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&org, "org", "o", defaultOrg, "ID of the organization the environment should be created under.")
+	cmd.Flags().StringVarP(&org, "org", "o", "", "ID of the organization the environment should be created under.")
 	cmd.Flags().StringVarP(&tag, "tag", "t", defaultImgTag, "tag of the image the environment will be based off of.")
-	cmd.Flags().Float32P("cpu", "c", defaultCPUCores, "number of cpu cores the environment should be provisioned with.")
-	cmd.Flags().Float32P("memory", "m", defaultMemGB, "GB of RAM an environment should be provisioned with.")
-	cmd.Flags().IntP("disk", "d", defaultDiskGB, "GB of disk storage an environment should be provisioned with.")
-	cmd.Flags().IntP("gpus", "g", defaultGPUs, "number GPUs an environment should be provisioned with.")
-	cmd.Flags().StringVarP(&img, "image", "i", "", "ID of the image to base the environment off of.")
+	cmd.Flags().Float32P("cpu", "c", 0, "number of cpu cores the environment should be provisioned with.")
+	cmd.Flags().Float32P("memory", "m", 0, "GB of RAM an environment should be provisioned with.")
+	cmd.Flags().IntP("disk", "d", 0, "GB of disk storage an environment should be provisioned with.")
+	cmd.Flags().IntP("gpus", "g", 0, "number GPUs an environment should be provisioned with.")
+	cmd.Flags().StringVarP(&img, "image", "i", "", "name of the image to base the environment off of.")
 	cmd.Flags().BoolVar(&follow, "follow", false, "follow buildlog after initiating rebuild")
 	_ = cmd.MarkFlagRequired("image")
 	return cmd
@@ -223,6 +252,7 @@ coder envs create --cpu 4 --disk 100 --memory 8 --image 5f443b16-30652892427b955
 
 func editEnvCommand(user *string) *cobra.Command {
 	var (
+		org      string
 		img      string
 		tag      string
 		cpuCores float32
@@ -242,13 +272,6 @@ func editEnvCommand(user *string) *cobra.Command {
 
 coder envs edit back-end-env --disk 20`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// We're explicitly ignoring these errors because if any of these
-			// fail we are left with the zero value for the corresponding numeric type.
-			cpuCores, _ = cmd.Flags().GetFloat32("cpu")
-			memGB, _ = cmd.Flags().GetFloat32("memory")
-			diskGB, _ = cmd.Flags().GetInt("disk")
-			gpus, _ = cmd.Flags().GetInt("gpus")
-
 			client, err := newClient()
 			if err != nil {
 				return err
@@ -261,48 +284,41 @@ coder envs edit back-end-env --disk 20`,
 				return err
 			}
 
-			var updateReq coder.UpdateEnvironmentReq
-
-			// If any of the flags have defaulted to zero-values, it implies the user does not wish to change that value.
-			// With that said, we can enforce this by reassigning the request field to the corresponding existing environment value.
-			if cpuCores == 0 {
-				updateReq.CPUCores = &env.CPUCores
-			} else {
-				updateReq.CPUCores = &cpuCores
+			multiOrgMember, err := isMultiOrgMember(cmd.Context(), client, *user)
+			if err != nil {
+				return err
 			}
 
-			if memGB == 0 {
-				updateReq.MemoryGB = &env.MemoryGB
-			} else {
-				updateReq.MemoryGB = &memGB
+			// if the user belongs to multiple organizations we need them to specify which one.
+			if multiOrgMember && org == "" {
+				return xerrors.New("org is required for multi-org members")
 			}
 
-			if diskGB == 0 {
-				updateReq.DiskGB = &env.DiskGB
-			} else {
-				updateReq.DiskGB = &diskGB
+			cpuCores, _ = cmd.Flags().GetFloat32("cpu")
+			memGB, _ = cmd.Flags().GetFloat32("memory")
+			diskGB, _ = cmd.Flags().GetInt("disk")
+			gpus, _ = cmd.Flags().GetInt("gpus")
+
+			req, err := buildUpdateReq(cmd.Context(),
+				updateConf{
+					cpu:         cpuCores,
+					memGB:       memGB,
+					diskGB:      diskGB,
+					gpus:        gpus,
+					client:      client,
+					environment: env,
+					user:        user,
+					image:       img,
+					imageTag:    tag,
+					orgName:     org,
+				},
+			)
+			if err != nil {
+				return err
 			}
 
-			if gpus == 0 {
-				updateReq.GPUs = &env.GPUs
-			} else {
-				updateReq.GPUs = &gpus
-			}
-
-			if img == "" {
-				updateReq.ImageID = &env.ImageID
-			} else {
-				updateReq.ImageID = &img
-			}
-
-			if tag == "" {
-				updateReq.ImageTag = &env.ImageTag
-			} else {
-				updateReq.ImageTag = &tag
-			}
-
-			if err := client.EditEnvironment(cmd.Context(), env.ID, updateReq); err != nil {
-				return xerrors.Errorf("failed to apply changes to environment: '%s'", envName)
+			if err := client.EditEnvironment(cmd.Context(), env.ID, *req); err != nil {
+				return xerrors.Errorf("failed to apply changes to environment %q: %w", envName, err)
 			}
 
 			if follow {
@@ -320,7 +336,8 @@ coder envs edit back-end-env --disk 20`,
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&img, "image", "i", "", "image ID of the image you wan't the environment to be based off of.")
+	cmd.Flags().StringVarP(&org, "org", "o", "", "name of the organization the environment should be created under.")
+	cmd.Flags().StringVarP(&img, "image", "i", "", "name of the image you wan't the environment to be based off of.")
 	cmd.Flags().StringVarP(&tag, "tag", "t", "latest", "image tag of the image you wan't to base the environment off of.")
 	cmd.Flags().Float32P("cpu", "c", cpuCores, "The number of cpu cores the environment should be provisioned with.")
 	cmd.Flags().Float32P("memory", "m", memGB, "The amount of RAM an environment should be provisioned with.")
@@ -386,4 +403,111 @@ func rmEnvsCommand(user *string) *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "force remove the specified environments without prompting first")
 	return cmd
+}
+
+type updateConf struct {
+	cpu         float32
+	memGB       float32
+	diskGB      int
+	gpus        int
+	client      *coder.Client
+	environment *coder.Environment
+	user        *string
+	image       string
+	imageTag    string
+	orgName     string
+}
+
+func buildUpdateReq(ctx context.Context, conf updateConf) (*coder.UpdateEnvironmentReq, error) {
+	var (
+		updateReq       coder.UpdateEnvironmentReq
+		defaultCPUCores float32
+		defaultMemGB    float32
+		defaultDiskGB   int
+	)
+
+	// If this is not empty it means the user is requesting to change the environment image.
+	if conf.image != "" {
+		importedImg, err := findImg(ctx,
+			findImgConf{
+				client:  conf.client,
+				email:   *conf.user,
+				imgName: conf.image,
+				orgName: conf.orgName,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// If the user passes an image arg of the image that
+		// the environment is already using, it was most likely a mistake.
+		if conf.image != importedImg.Repository {
+			return nil, xerrors.Errorf("environment is already using image %q", conf.image)
+		}
+
+		// Since the environment image is being changed,
+		// the resource amount defaults should be changed to
+		// reflect that of the default resource amounts of the new image.
+		defaultCPUCores = importedImg.DefaultCPUCores
+		defaultMemGB = importedImg.DefaultMemoryGB
+		defaultDiskGB = importedImg.DefaultDiskGB
+		updateReq.ImageID = &importedImg.ID
+	} else {
+		// if the environment image is not being changed, the default
+		// resource amounts should reflect the default resource amounts
+		// of the image the environment is already using.
+		defaultCPUCores = conf.environment.CPUCores
+		defaultMemGB = conf.environment.MemoryGB
+		defaultDiskGB = conf.environment.DiskGB
+		updateReq.ImageID = &conf.environment.ImageID
+	}
+
+	// The following logic checks to see if the user specified
+	// any resource amounts for the environment that need to be changed.
+	// If they did not, then we will get the zero value back
+	// and should set the resource amount to the default.
+
+	if conf.cpu == 0 {
+		updateReq.CPUCores = &defaultCPUCores
+	} else {
+		updateReq.CPUCores = &conf.cpu
+	}
+
+	if conf.memGB == 0 {
+		updateReq.MemoryGB = &defaultMemGB
+	} else {
+		updateReq.MemoryGB = &conf.memGB
+	}
+
+	if conf.diskGB == 0 {
+		updateReq.DiskGB = &defaultDiskGB
+	} else {
+		updateReq.DiskGB = &conf.diskGB
+	}
+
+	// Environment disks can not be shrink so we have to overwrite this
+	// if the user accidentally requests it or if the default diskGB value for a
+	// newly requested image is smaller than the current amount the environment is using.
+	if *updateReq.DiskGB < conf.environment.DiskGB {
+		clog.LogWarn("disk can not be shrunk",
+			fmt.Sprintf("keeping environment disk at %d GB", conf.environment.DiskGB),
+		)
+		updateReq.DiskGB = &conf.environment.DiskGB
+	}
+
+	if conf.gpus != 0 {
+		updateReq.GPUs = &conf.gpus
+	}
+
+	if conf.imageTag == "" {
+		// We're forced to make an alloc here because untyped string consts are not addressable.
+		// i.e.  updateReq.ImageTag = &defaultImgTag results in :
+		// invalid operation: cannot take address of defaultImgTag (untyped string constant "latest")
+		imgTag := defaultImgTag
+		updateReq.ImageTag = &imgTag
+	} else {
+		updateReq.ImageTag = &conf.imageTag
+	}
+	return &updateReq, nil
 }


### PR DESCRIPTION
# What this does

- Users can pass the image name to the `--image` flag instead of having to pass the image id.
- This applies to both coder `create` and `edit`
- Coder `create` and `edit` both now source default resource amounts based on the imported image vs arbitrary ones we had previously defined in the CLI.

# Create

## Create environment with default resource amounts

This screenshot also demonstrates some examples of errors users might have.

<img width="726" alt="create" src="https://user-images.githubusercontent.com/34631293/97341971-b3a1a700-1853-11eb-8f14-f5a689479093.png">


## Create environment with custom resource amounts

<img width="740" alt="create_w_custom" src="https://user-images.githubusercontent.com/34631293/97342001-bd2b0f00-1853-11eb-8901-1892d649c08e.png">


# Edit

## Change the image of an environment

When an environment image is changed and resource amounts are left unspecified, the resource amounts will be changed to that of the default resource amounts specified by the new image the environment will be using.

Also not there's a caveat here in the screenshot it's worth being aware of. Notice when we are going from `codercom/enterprise-dev` to `ubuntu` that we get a warning message about how we can't reduce the amount of disk storage. The ubuntu default is 10 so the tool is smart enough to recognize that the default amount of the new image for disk is smaller than what it's currently using and keeps it the same while warning the user.

<img width="730" alt="edit_image" src="https://user-images.githubusercontent.com/34631293/97342205-f95e6f80-1853-11eb-9ff5-c0b1b0ba20bc.png">

## Change the resource amounts of an environment

<img width="696" alt="edit_resoures" src="https://user-images.githubusercontent.com/34631293/97342230-01b6aa80-1854-11eb-978d-cc120ca575a5.png">

## Change both the image and resource amounts of an environment

<img width="694" alt="edit_both" src="https://user-images.githubusercontent.com/34631293/97342311-14c97a80-1854-11eb-91e8-3b95dfc6ba27.png">

