### PR TITLE
Add basic env create|edit integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,5 +22,5 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.14'
-      - name: go test
-        run: go test -v ./ci/integration/...
+      - name: integration tests
+        run: ./ci/steps/integration.sh

--- a/ci/integration/Dockerfile
+++ b/ci/integration/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y jq curl

--- a/ci/integration/devurls_test.go
+++ b/ci/integration/devurls_test.go
@@ -12,7 +12,6 @@ func TestDevURLCLI(t *testing.T) {
 	run(t, "coder-cli-devurl-tests", func(t *testing.T, ctx context.Context, c *tcli.ContainerRunner) {
 		c.Run(ctx, "which coder").Assert(t,
 			tcli.Success(),
-			tcli.StdoutMatches("/usr/sbin/coder"),
 			tcli.StderrEmpty(),
 		)
 

--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -87,7 +87,7 @@ func TestCoderCLI(t *testing.T) {
 var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func randString(length int) string {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	const charset = "abcdefghijklmnopqrstuvwxyz"
 	b := make([]byte, length)
 	for i := range b {
 		b[i] = charset[seededRand.Intn(len(charset))]

--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -18,7 +18,7 @@ func run(t *testing.T, container string, execute func(t *testing.T, ctx context.
 		defer cancel()
 
 		c, err := tcli.NewContainerRunner(ctx, &tcli.ContainerConfig{
-			Image: "codercom/enterprise-dev",
+			Image: "coder-cli-integration:latest",
 			Name:  container,
 			BindMounts: map[string]string{
 				binpath: "/bin/coder",
@@ -36,7 +36,6 @@ func TestCoderCLI(t *testing.T) {
 	run(t, "test-coder-cli", func(t *testing.T, ctx context.Context, c *tcli.ContainerRunner) {
 		c.Run(ctx, "which coder").Assert(t,
 			tcli.Success(),
-			tcli.StdoutMatches("/usr/sbin/coder"),
 			tcli.StderrEmpty(),
 		)
 

--- a/ci/integration/setup_test.go
+++ b/ci/integration/setup_test.go
@@ -51,14 +51,17 @@ func build(path string) error {
 // write session tokens to the given container runner
 func headlessLogin(ctx context.Context, t *testing.T, runner *tcli.ContainerRunner) {
 	creds := login(ctx, t)
-	cmd := exec.CommandContext(ctx, "sh", "-c", "mkdir -p ~/.config/coder && cat > ~/.config/coder/session")
+	cmd := exec.CommandContext(ctx, "sh", "-c", "mkdir -p $HOME/.config/coder && cat > $HOME/.config/coder/session")
 
 	// !IMPORTANT: be careful that this does not appear in logs
 	cmd.Stdin = strings.NewReader(creds.token)
 	runner.RunCmd(cmd).Assert(t,
 		tcli.Success(),
 	)
-	runner.Run(ctx, fmt.Sprintf("echo -ne %s > ~/.config/coder/url", creds.url)).Assert(t,
+
+	cmd = exec.CommandContext(ctx, "sh", "-c", "cat > $HOME/.config/coder/url")
+	cmd.Stdin = strings.NewReader(creds.url)
+	runner.RunCmd(cmd).Assert(t,
 		tcli.Success(),
 	)
 }

--- a/ci/integration/users_test.go
+++ b/ci/integration/users_test.go
@@ -14,7 +14,6 @@ func TestUsers(t *testing.T) {
 	run(t, "users-cli-tests", func(t *testing.T, ctx context.Context, c *tcli.ContainerRunner) {
 		c.Run(ctx, "which coder").Assert(t,
 			tcli.Success(),
-			tcli.StdoutMatches("/usr/sbin/coder"),
 			tcli.StderrEmpty(),
 		)
 

--- a/ci/steps/integration.sh
+++ b/ci/steps/integration.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+log() {
+  echo "--- $@"
+}
+
+cd "$(git rev-parse --show-toplevel)"
+
+log "building integration test image"
+docker build -f ./ci/integration/Dockerfile -t coder-cli-integration:latest .
+
+log "starting integration tests"
+go test ./ci/integration -count=1

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cdr.dev/wsep v0.0.0-20200728013649-82316a09813f
 	github.com/briandowns/spinner v1.11.1
 	github.com/fatih/color v1.9.0
+	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/klauspost/compress v1.10.8 // indirect


### PR DESCRIPTION
This PR adds integration tests for `coder envs create` and `coder envs edit`. Given that we do not have an interface for importing images, it's best that we hold off on making these test fully stateless.