### PR TITLE
Unhide rebuild and watch-build commands

### DIFF
--- a/docs/coder_envs.md
+++ b/docs/coder_envs.md
@@ -23,5 +23,7 @@ Perform operations on the Coder environments owned by the active user.
 
 * [coder](coder.md)	 - coder provides a CLI for working with an existing Coder Enterprise installation
 * [coder envs ls](coder_envs_ls.md)	 - list all environments owned by the active user
+* [coder envs rebuild](coder_envs_rebuild.md)	 - rebuild a Coder environment
 * [coder envs stop](coder_envs_stop.md)	 - stop Coder environments by name
+* [coder envs watch-build](coder_envs_watch-build.md)	 - trail the build log of a Coder environment
 

--- a/docs/coder_envs_rebuild.md
+++ b/docs/coder_envs_rebuild.md
@@ -1,0 +1,34 @@
+## coder envs rebuild
+
+rebuild a Coder environment
+
+```
+coder envs rebuild [environment_name] [flags]
+```
+
+### Examples
+
+```
+coder envs rebuild front-end-env --follow
+coder envs rebuild backend-env --force
+```
+
+### Options
+
+```
+      --follow   follow build log after initiating rebuild
+      --force    force rebuild without showing a confirmation prompt
+  -h, --help     help for rebuild
+```
+
+### Options inherited from parent commands
+
+```
+      --user string   Specify the user whose resources to target (default "me")
+  -v, --verbose       show verbose output
+```
+
+### SEE ALSO
+
+* [coder envs](coder_envs.md)	 - Interact with Coder environments
+

--- a/docs/coder_envs_watch-build.md
+++ b/docs/coder_envs_watch-build.md
@@ -9,7 +9,7 @@ coder envs watch-build [environment_name] [flags]
 ### Examples
 
 ```
-coder watch-build front-end-env
+coder envs watch-build front-end-env
 ```
 
 ### Options

--- a/docs/coder_envs_watch-build.md
+++ b/docs/coder_envs_watch-build.md
@@ -1,0 +1,31 @@
+## coder envs watch-build
+
+trail the build log of a Coder environment
+
+```
+coder envs watch-build [environment_name] [flags]
+```
+
+### Examples
+
+```
+coder watch-build front-end-env
+```
+
+### Options
+
+```
+  -h, --help   help for watch-build
+```
+
+### Options inherited from parent commands
+
+```
+      --user string   Specify the user whose resources to target (default "me")
+  -v, --verbose       show verbose output
+```
+
+### SEE ALSO
+
+* [coder envs](coder_envs.md)	 - Interact with Coder environments
+

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -30,8 +30,8 @@ func envsCommand() *cobra.Command {
 		lsEnvsCommand(&user),
 		stopEnvsCommand(&user),
 		rmEnvsCommand(&user),
-		watchBuildLogCommand(),
-		rebuildEnvCommand(),
+		watchBuildLogCommand(&user),
+		rebuildEnvCommand(&user),
 		createEnvCommand(&user),
 		editEnvCommand(&user),
 	)

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func rebuildEnvCommand() *cobra.Command {
+func rebuildEnvCommand(user *string) *cobra.Command {
 	var follow bool
 	var force bool
 	cmd := &cobra.Command{
@@ -32,7 +32,7 @@ coder envs rebuild backend-env --force`,
 			if err != nil {
 				return err
 			}
-			env, err := findEnv(ctx, client, args[0], coder.Me)
+			env, err := findEnv(ctx, client, args[0], *user)
 			if err != nil {
 				return err
 			}
@@ -136,7 +136,7 @@ func trailBuildLogs(ctx context.Context, client *coder.Client, envID string) err
 	return nil
 }
 
-func watchBuildLogCommand() *cobra.Command {
+func watchBuildLogCommand(user *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "watch-build [environment_name]",
 		Example: "coder watch-build front-end-env",
@@ -148,7 +148,7 @@ func watchBuildLogCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			env, err := findEnv(ctx, client, args[0], coder.Me)
+			env, err := findEnv(ctx, client, args[0], *user)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -26,7 +26,6 @@ func rebuildEnvCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Example: `coder envs rebuild front-end-env --follow
 coder envs rebuild backend-env --force`,
-		Hidden: true, // TODO(@cmoog) un-hide
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient()
@@ -44,7 +43,10 @@ coder envs rebuild backend-env --force`,
 					IsConfirm: true,
 				}).Run()
 				if err != nil {
-					return err
+					return clog.Fatal(
+						"failed to confirm prompt", clog.BlankLine, 
+						clog.Tipf(`use "--force" to rebuild without a confirmation prompt`),
+					)
 				}
 			}
 
@@ -65,7 +67,7 @@ coder envs rebuild backend-env --force`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&follow, "follow", false, "follow buildlog after initiating rebuild")
+	cmd.Flags().BoolVar(&follow, "follow", false, "follow build log after initiating rebuild")
 	cmd.Flags().BoolVar(&force, "force", false, "force rebuild without showing a confirmation prompt")
 	return cmd
 }
@@ -140,7 +142,6 @@ func watchBuildLogCommand() *cobra.Command {
 		Example: "coder watch-build front-end-env",
 		Short:   "trail the build log of a Coder environment",
 		Args:    cobra.ExactArgs(1),
-		Hidden:  true, // TODO(@cmoog) un-hide
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient()

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -139,7 +139,7 @@ func trailBuildLogs(ctx context.Context, client *coder.Client, envID string) err
 func watchBuildLogCommand(user *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "watch-build [environment_name]",
-		Example: "coder watch-build front-end-env",
+		Example: "coder envs watch-build front-end-env",
 		Short:   "trail the build log of a Coder environment",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -77,7 +77,7 @@ coder envs rebuild backend-env --force`,
 func trailBuildLogs(ctx context.Context, client *coder.Client, envID string) error {
 	const check = "✅"
 	const failure = "❌"
-=
+
 	newSpinner := func() *spinner.Spinner { return spinner.New(spinner.CharSets[11], 100*time.Millisecond) }
 
 	// this tells us whether to show dynamic loaders when printing output

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -44,7 +44,7 @@ coder envs rebuild backend-env --force`,
 				}).Run()
 				if err != nil {
 					return clog.Fatal(
-						"failed to confirm prompt", clog.BlankLine, 
+						"failed to confirm prompt", clog.BlankLine,
 						clog.Tipf(`use "--force" to rebuild without a confirmation prompt`),
 					)
 				}
@@ -77,7 +77,7 @@ coder envs rebuild backend-env --force`,
 func trailBuildLogs(ctx context.Context, client *coder.Client, envID string) error {
 	const check = "✅"
 	const failure = "❌"
-
+=
 	newSpinner := func() *spinner.Spinner { return spinner.New(spinner.CharSets[11], 100*time.Millisecond) }
 
 	// this tells us whether to show dynamic loaders when printing output


### PR DESCRIPTION
This PR unhides and generates documentation for two new subcommands:
```
$ coder envs rebuild [env_name]
$ coder envs watch-build [env_name]
```