### PR TITLE
Unhide coder envs rm command

### DIFF
--- a/docs/coder_envs.md
+++ b/docs/coder_envs.md
@@ -24,6 +24,7 @@ Perform operations on the Coder environments owned by the active user.
 * [coder](coder.md)	 - coder provides a CLI for working with an existing Coder Enterprise installation
 * [coder envs ls](coder_envs_ls.md)	 - list all environments owned by the active user
 * [coder envs rebuild](coder_envs_rebuild.md)	 - rebuild a Coder environment
+* [coder envs rm](coder_envs_rm.md)	 - remove Coder environments by name
 * [coder envs stop](coder_envs_stop.md)	 - stop Coder environments by name
 * [coder envs watch-build](coder_envs_watch-build.md)	 - trail the build log of a Coder environment
 

--- a/docs/coder_envs_rm.md
+++ b/docs/coder_envs_rm.md
@@ -1,0 +1,26 @@
+## coder envs rm
+
+remove Coder environments by name
+
+```
+coder envs rm [...environment_names] [flags]
+```
+
+### Options
+
+```
+  -f, --force   force remove the specified environments without prompting first
+  -h, --help    help for rm
+```
+
+### Options inherited from parent commands
+
+```
+      --user string   Specify the user whose resources to target (default "me")
+  -v, --verbose       show verbose output
+```
+
+### SEE ALSO
+
+* [coder envs](coder_envs.md)	 - Interact with Coder environments
+

--- a/internal/clog/error.go
+++ b/internal/clog/error.go
@@ -78,19 +78,6 @@ func LogWarn(header string, lines ...string) {
 	}.String())
 }
 
-// Warn creates an error with the level "warning".
-func Warn(header string, lines ...string) CLIError {
-	return CLIError{
-		CLIMessage: CLIMessage{
-			Color:  color.FgYellow,
-			Level:  "warning",
-			Header: header,
-			Lines:  lines,
-		},
-		error: errors.New(header),
-	}
-}
-
 // Error creates an error with the level "error".
 func Error(header string, lines ...string) CLIError {
 	return CLIError{

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -33,7 +33,7 @@ func newClient() (*coder.Client, error) {
 
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, xerrors.Errorf("url misformatted: %w try runing \"coder login\" with a valid URL", err)
+		return nil, xerrors.Errorf("url malformed: %w try runing \"coder login\" with a valid URL", err)
 	}
 
 	c := &coder.Client{
@@ -54,12 +54,12 @@ func newClient() (*coder.Client, error) {
 	}
 
 	if !version.VersionsMatch(apiVersion) {
-		clog.Log(clog.Warn(
+		clog.LogWarn(
 			"version mismatch detected",
 			fmt.Sprintf("coder-cli version: %s", version.Version),
 			fmt.Sprintf("Coder API version: %s", apiVersion), clog.BlankLine,
 			clog.Tipf("download the appropriate version here: https://github.com/cdr/coder-cli/releases"),
-		))
+		)
 	}
 
 	return c, nil

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -326,8 +326,8 @@ coder envs edit back-end-env --disk 20`,
 		},
 	}
 	cmd.Flags().StringVarP(&org, "org", "o", "", "name of the organization the environment should be created under.")
-	cmd.Flags().StringVarP(&img, "image", "i", "", "name of the image you wan't the environment to be based off of.")
-	cmd.Flags().StringVarP(&tag, "tag", "t", "latest", "image tag of the image you wan't to base the environment off of.")
+	cmd.Flags().StringVarP(&img, "image", "i", "", "name of the image you want the environment to be based off of.")
+	cmd.Flags().StringVarP(&tag, "tag", "t", "latest", "image tag of the image you want to base the environment off of.")
 	cmd.Flags().Float32P("cpu", "c", cpuCores, "The number of cpu cores the environment should be provisioned with.")
 	cmd.Flags().Float32P("memory", "m", memGB, "The amount of RAM an environment should be provisioned with.")
 	cmd.Flags().IntP("disk", "d", diskGB, "The amount of disk storage an environment should be provisioned with.")
@@ -339,10 +339,9 @@ coder envs edit back-end-env --disk 20`,
 func rmEnvsCommand(user *string) *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
-		Use:    "rm [...environment_names]",
-		Short:  "remove Coder environments by name",
-		Hidden: true,
-		Args:   cobra.MinimumNArgs(1),
+		Use:   "rm [...environment_names]",
+		Short: "remove Coder environments by name",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient()
@@ -355,7 +354,10 @@ func rmEnvsCommand(user *string) *cobra.Command {
 					IsConfirm: true,
 				}
 				if _, err := confirm.Run(); err != nil {
-					return err
+					return clog.Fatal(
+						"failed to confirm prompt", clog.BlankLine,
+						clog.Tipf(`use "--force" to rebuild without a confirmation prompt`),
+					)
 				}
 			}
 


### PR DESCRIPTION
This PR unhides and generates documentation for the `coder envs rm` command.