### PR TITLE
Add config sdk methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ci/bin
 cmd/coder/coder
 ci/integration/bin
 ci/integration/env.sh
+coder-sdk/env.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,3 +15,32 @@ linters-settings:
           - (cdr.dev/coder-cli/pkg/clog).Tipf
           - (cdr.dev/coder-cli/pkg/clog).Hintf
           - (cdr.dev/coder-cli/pkg/clog).Causef
+linters:
+  disable-all: true
+  enable:
+    - megacheck
+    - govet
+    - golint
+    - goconst
+    - gocognit
+    - nestif
+    - misspell
+    - unparam
+    - unused
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - unconvert
+    - unparam
+    - varcheck
+    - whitespace    
+    - structcheck
+    - stylecheck
+    - typecheck
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - scopelint
+    - goprintffuncname

--- a/ci/integration/devurls_test.go
+++ b/ci/integration/devurls_test.go
@@ -76,5 +76,4 @@ func TestDevURLCLI(t *testing.T) {
 	// c.Run(ctx, `coder urls ls env1 -o json | jq -c '.[] | select( .name == "foobar")'`).Assert(t,
 	// 	tcli.Error(),
 	// 	jsonUnmarshals(&durl))
-
 }

--- a/ci/integration/envs_test.go
+++ b/ci/integration/envs_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func cleanupClient(t *testing.T, ctx context.Context) *coder.Client {
+func cleanupClient(ctx context.Context, t *testing.T) *coder.Client {
 	creds := login(ctx, t)
 
 	u, err := url.Parse(creds.url)
@@ -41,7 +41,7 @@ func TestEnvsCLI(t *testing.T) {
 
 	run(t, "coder-cli-env-tests", func(t *testing.T, ctx context.Context, c *tcli.ContainerRunner) {
 		headlessLogin(ctx, t, c)
-		client := cleanupClient(t, ctx)
+		client := cleanupClient(ctx, t)
 
 		// Minimum args not received.
 		c.Run(ctx, "coder envs create").Assert(t,
@@ -101,7 +101,7 @@ func TestEnvsCLI(t *testing.T) {
 
 	run(t, "coder-cli-env-edit-tests", func(t *testing.T, ctx context.Context, c *tcli.ContainerRunner) {
 		headlessLogin(ctx, t, c)
-		client := cleanupClient(t, ctx)
+		client := cleanupClient(ctx, t)
 
 		name := randString(10)
 		c.Run(ctx, fmt.Sprintf("coder envs create %s --image ubuntu --follow", name)).Assert(t,

--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -80,7 +80,6 @@ func TestCoderCLI(t *testing.T) {
 			tcli.Error(),
 		)
 	})
-
 }
 
 var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/ci/steps/unit_test.sh
+++ b/ci/steps/unit_test.sh
@@ -6,4 +6,4 @@ cd "$(git rev-parse --show-toplevel)"
 
 echo "--- go test..."
 
-go test $(go list ./... | grep -v pkg/tcli | grep -v ci/integration)
+go test $(go list ./... | grep -v pkg/tcli | grep -v ci/integration | grep -v coder-sdk)

--- a/coder-sdk/config.go
+++ b/coder-sdk/config.go
@@ -58,7 +58,7 @@ type ConfigOAuth struct {
 
 func (c Client) SiteConfigAuth(ctx context.Context) (*ConfigAuth, error) {
 	var conf ConfigAuth
-	if err := c.requestBody(ctx, http.MethodGet, "/api/auth/config", nil, &c); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/auth/config", nil, &conf); err != nil {
 		return nil, err
 	}
 	return &conf, nil
@@ -117,5 +117,5 @@ func (c Client) SiteConfigExtensionMarketplace(ctx context.Context) (*ConfigExte
 }
 
 func (c Client) PutSiteConfigExtensionMarketplace(ctx context.Context, req ConfigExtensionMarketplace) error {
-	return c.requestBody(ctx, http.MethodGet, "/api/extensions/config", req, nil)
+	return c.requestBody(ctx, http.MethodPut, "/api/extensions/config", req, nil)
 }

--- a/coder-sdk/config.go
+++ b/coder-sdk/config.go
@@ -1,0 +1,121 @@
+package coder
+
+import (
+	"context"
+	"net/http"
+)
+
+type AuthProviderType string
+
+// AuthProviderType enum.
+const (
+	AuthProviderBuiltIn AuthProviderType = "built-in"
+	AuthProviderSAML    AuthProviderType = "saml"
+	AuthProviderOIDC    AuthProviderType = "oidc"
+)
+
+type ConfigAuth struct {
+	ProviderType *AuthProviderType `json:"provider_type"`
+	OIDC         *ConfigOIDC       `json:"oidc"`
+	SAML         *ConfigSAML       `json:"saml"`
+}
+
+type ConfigOIDC struct {
+	ClientID     *string `json:"client_id"`
+	ClientSecret *string `json:"client_secret"`
+	Issuer       *string `json:"issuer"`
+}
+
+type ConfigSAML struct {
+	IdentityProviderMetadataURL *string `json:"idp_metadata_url"`
+	SignatureAlgorithm          *string `json:"signature_algorithm"`
+	NameIDFormat                *string `json:"name_id_format"`
+	PrivateKey                  *string `json:"private_key"`
+	PublicKeyCertificate        *string `json:"public_key_certificate"`
+}
+
+type ConfigOAuthBitbucketServer struct {
+	BaseURL string `json:"base_url" diff:"oauth.bitbucket_server.base_url"`
+}
+
+type ConfigOAuthGitHub struct {
+	BaseURL      string `json:"base_url"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+type ConfigOAuthGitLab struct {
+	BaseURL      string `json:"base_url"`
+	ClientID     string `json:"client_id" `
+	ClientSecret string `json:"client_secret"`
+}
+
+type ConfigOAuth struct {
+	BitbucketServer ConfigOAuthBitbucketServer `json:"bitbucket_server"`
+	GitHub          ConfigOAuthGitHub          `json:"github"`
+	GitLab          ConfigOAuthGitLab          `json:"gitlab"`
+}
+
+func (c Client) SiteConfigAuth(ctx context.Context) (*ConfigAuth, error) {
+	var conf ConfigAuth
+	if err := c.requestBody(ctx, http.MethodGet, "/api/auth/config", nil, &c); err != nil {
+		return nil, err
+	}
+	return &conf, nil
+}
+
+func (c Client) PutSiteConfigAuth(ctx context.Context, req ConfigAuth) error {
+	return c.requestBody(ctx, http.MethodPut, "/api/auth/config", req, nil)
+}
+
+func (c Client) SiteConfigOAuth(ctx context.Context) (*ConfigOAuth, error) {
+	var conf ConfigOAuth
+	if err := c.requestBody(ctx, http.MethodGet, "/api/oauth/config", nil, &conf); err != nil {
+		return nil, err
+	}
+	return &conf, nil
+}
+
+func (c Client) PutSiteConfigOAuth(ctx context.Context, req ConfigOAuth) error {
+	return c.requestBody(ctx, http.MethodPut, "/api/oauth/config", req, nil)
+}
+
+type configSetupMode struct {
+	SetupMode bool `json:"setup_mode"`
+}
+
+func (c Client) SiteSetupModeEnabled(ctx context.Context) (bool, error) {
+	var conf configSetupMode
+	if err := c.requestBody(ctx, http.MethodGet, "/api/config/setup-mode", nil, &conf); err != nil {
+		return false, nil
+	}
+	return conf.SetupMode, nil
+}
+
+type ExtensionMarketplaceType string
+
+// ExtensionMarketplaceType enum.
+const (
+	ExtensionMarketplaceInternal ExtensionMarketplaceType = "internal"
+	ExtensionMarketplaceCustom   ExtensionMarketplaceType = "custom"
+	ExtensionMarketplacePublic   ExtensionMarketplaceType = "public"
+)
+
+const MarketplaceExtensionPublicURL = "https://extensions.coder.com/api"
+
+type ConfigExtensionMarketplace struct {
+	URL  string                   `json:"url"`
+	Type ExtensionMarketplaceType `json:"type"`
+}
+
+func (c Client) SiteConfigExtensionMarketplace(ctx context.Context) (*ConfigExtensionMarketplace, error) {
+	var conf ConfigExtensionMarketplace
+	if err := c.requestBody(ctx, http.MethodGet, "/api/extensions/config", nil, &conf); err != nil {
+		return nil, err
+	}
+	return &conf, nil
+}
+
+func (c Client) PutSiteConfigExtensionMarketplace(ctx context.Context, req ConfigExtensionMarketplace) error {
+	return c.requestBody(ctx, http.MethodGet, "/api/extensions/config", req, nil)
+}

--- a/coder-sdk/config_test.go
+++ b/coder-sdk/config_test.go
@@ -1,0 +1,66 @@
+package coder_test
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/slogtest"
+	"cdr.dev/slog/sloggers/slogtest/assert"
+)
+
+func newClient(t *testing.T) *coder.Client {
+	token := os.Getenv("CODER_TOKEN")
+	if token == "" {
+		slogtest.Fatal(t, `"CODER_TOKEN" env var is empty`)
+	}
+	raw := os.Getenv("CODER_URL")
+	u, err := url.Parse(raw)
+	if err != nil {
+		slogtest.Fatal(t, `"CODER_URL" env var is invalid`, slog.Error(err))
+	}
+
+	return &coder.Client{
+		BaseURL: u,
+		Token:   token,
+	}
+}
+
+func TestConfig(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	client := newClient(t)
+
+	version, err := client.APIVersion(ctx)
+	assert.Success(t, "get api version", err)
+	slogtest.Info(t, "got api version", slog.F("version", version))
+
+	authConfig, err := client.SiteConfigAuth(ctx)
+	assert.Success(t, "auth config", err)
+	slogtest.Info(t, "got site auth config", slog.F("config", authConfig))
+
+	oauthConf, err := client.SiteConfigOAuth(ctx)
+	assert.Success(t, "auth config", err)
+	slogtest.Info(t, "got site oauth config", slog.F("config", oauthConf))
+
+	putOAuth := &coder.ConfigOAuth{
+		GitHub: coder.ConfigOAuthGitHub{
+			BaseURL:      "github.com",
+			ClientID:     "fake client id",
+			ClientSecret: "fake secrets",
+		},
+	}
+
+	err = client.PutSiteConfigOAuth(ctx, *putOAuth)
+	assert.Success(t, "put site oauth", err)
+
+	oauthConf, err = client.SiteConfigOAuth(ctx)
+	assert.Success(t, "auth config", err)
+	assert.Equal(t, "oauth was updated", putOAuth, oauthConf)
+}

--- a/coder-sdk/doc.go
+++ b/coder-sdk/doc.go
@@ -1,0 +1,2 @@
+// Package coder provides simple APIs for integrating Go applications with Coder Enterprise.
+package coder

--- a/coder-sdk/secrets.go
+++ b/coder-sdk/secrets.go
@@ -87,8 +87,10 @@ func (c *Client) DeleteSecretByName(ctx context.Context, name, userID string) er
 	// Delete the secret.
 	// NOTE: This is racy, but acceptable. If the secret is gone or the permission changed since we looked up the id,
 	//       the call will simply fail and surface the error to the user.
-	if _, err := c.request(ctx, http.MethodDelete, "/api/users/"+userID+"/secrets/"+secret.ID, nil); err != nil {
+	resp, err := c.request(ctx, http.MethodDelete, "/api/users/"+userID+"/secrets/"+secret.ID, nil)
+	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	return nil
 }

--- a/coder-sdk/users.go
+++ b/coder-sdk/users.go
@@ -125,3 +125,7 @@ type CreateUserReq struct {
 func (c Client) CreateUser(ctx context.Context, req CreateUserReq) error {
 	return c.requestBody(ctx, http.MethodPost, "/api/users", req, nil)
 }
+
+func (c Client) DeleteUser(ctx context.Context, userID string) error {
+	return c.requestBody(ctx, http.MethodDelete, "/api/users/"+userID, nil, nil)
+}

--- a/coder-sdk/version.go
+++ b/coder-sdk/version.go
@@ -12,6 +12,7 @@ func (c Client) APIVersion(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	version := resp.Header.Get(coderVersionHeaderKey)
 	if version == "" {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -44,7 +44,7 @@ func newClient(ctx context.Context) (*coder.Client, error) {
 
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, xerrors.Errorf("url malformed: %w try runing \"coder login\" with a valid URL", err)
+		return nil, xerrors.Errorf("url malformed: %w try running \"coder login\" with a valid URL", err)
 	}
 
 	c := &coder.Client{

--- a/internal/cmd/configssh.go
+++ b/internal/cmd/configssh.go
@@ -153,7 +153,7 @@ func writeSSHKey(ctx context.Context, client *coder.Client, privateKeyPath strin
 func makeNewConfigs(userName string, envs []coder.Environment, startToken, startMsg, endToken, privateKeyFilepath string) (string, error) {
 	hostname, err := configuredHostname()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	newConfig := fmt.Sprintf("\n%s\n%s\n\n", startToken, startMsg)

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -38,6 +38,11 @@ func envsCmd() *cobra.Command {
 	return cmd
 }
 
+const (
+	humanOutput = "human"
+	jsonOutput  = "json"
+)
+
 func lsEnvsCommand(user *string) *cobra.Command {
 	var outputFmt string
 
@@ -61,14 +66,14 @@ func lsEnvsCommand(user *string) *cobra.Command {
 			}
 
 			switch outputFmt {
-			case "human":
+			case humanOutput:
 				err := tablewriter.WriteTable(len(envs), func(i int) interface{} {
 					return envs[i]
 				})
 				if err != nil {
 					return xerrors.Errorf("write table: %w", err)
 				}
-			case "json":
+			case jsonOutput:
 				err := json.NewEncoder(os.Stdout).Encode(envs)
 				if err != nil {
 					return xerrors.Errorf("write environments as JSON: %w", err)
@@ -80,7 +85,7 @@ func lsEnvsCommand(user *string) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&outputFmt, "output", "o", "human", "human | json")
+	cmd.Flags().StringVarP(&outputFmt, "output", "o", humanOutput, "human | json")
 
 	return cmd
 }

--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -166,7 +166,7 @@ func runCommand(ctx context.Context, envName, command string, args []string) err
 	if err != nil {
 		var closeErr websocket.CloseError
 		if xerrors.As(err, &closeErr) {
-			return networkErr(client, env)
+			return networkErr(env)
 		}
 		return xerrors.Errorf("start remote command: %w", err)
 	}
@@ -200,14 +200,14 @@ func runCommand(ctx context.Context, envName, command string, args []string) err
 	if err := process.Wait(); err != nil {
 		var closeErr websocket.CloseError
 		if xerrors.Is(err, ctx.Err()) || xerrors.As(err, &closeErr) {
-			return networkErr(client, env)
+			return networkErr(env)
 		}
 		return err
 	}
 	return nil
 }
 
-func networkErr(client *coder.Client, env *coder.Environment) error {
+func networkErr(env *coder.Environment) error {
 	if env.LatestStat.ContainerStatus != coder.EnvironmentOn {
 		return clog.Fatal(
 			"environment is not running",

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -23,7 +23,7 @@ func usersCmd() *cobra.Command {
 coder users ls -o json | jq .[] | jq -r .email`,
 		RunE: listUsers(&outputFmt),
 	}
-	lsCmd.Flags().StringVarP(&outputFmt, "output", "o", "human", "human | json")
+	lsCmd.Flags().StringVarP(&outputFmt, "output", "o", humanOutput, "human | json")
 
 	cmd.AddCommand(lsCmd)
 	return cmd
@@ -43,7 +43,7 @@ func listUsers(outputFmt *string) func(cmd *cobra.Command, args []string) error 
 		}
 
 		switch *outputFmt {
-		case "human":
+		case humanOutput:
 			// For each element, return the user.
 			each := func(i int) interface{} { return users[i] }
 			if err := tablewriter.WriteTable(len(users), each); err != nil {

--- a/internal/sync/eventcache.go
+++ b/internal/sync/eventcache.go
@@ -40,7 +40,6 @@ func (cache eventCache) SequentialEvents() []timedEvent {
 		// Include files that have deleted here.
 		// It's unclear whether they're files or folders.
 		r = append(r, ev)
-
 	}
 	return r
 }
@@ -58,7 +57,6 @@ func (cache eventCache) ConcurrentEvents() []timedEvent {
 			continue
 		}
 		r = append(r, ev)
-
 	}
 	return r
 }

--- a/internal/x/xterminal/terminal.go
+++ b/internal/x/xterminal/terminal.go
@@ -62,7 +62,7 @@ func ResizeEvents(ctx context.Context, termFD uintptr) chan ResizeEvent {
 		signal.Notify(sigChan, unix.SIGWINCH)
 		defer signal.Stop(sigChan)
 
-		// Emit an inital signal event to make sure the server receives our current window size.
+		// Emit an initial signal event to make sure the server receives our current window size.
 		select {
 		case <-ctx.Done():
 			return
@@ -87,7 +87,6 @@ func ResizeEvents(ctx context.Context, termFD uintptr) chan ResizeEvent {
 					return
 				case events <- event:
 				}
-
 			}
 		}
 	}()


### PR DESCRIPTION
I'm thinking we have the unit tests in cdr/c run the `coder-sdk` unit tests pointed at the test API server and database. We're not really able to run the tests here until we have proper test clusters.