### PR TITLE
Release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: ${{ github.ref }}
           body: ""
           draft: true
           prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           draft: true
           prerelease: false
       - name: Upload Windows Release
-        id: upload-release-asset 
+        id: upload-windows-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
           asset_name: coder-cli-linux-amd64.tar.gz
           asset_content_type: application/zip
       - name: Upload MacOS Release
-        id: upload-release-asset 
+        id: upload-macos-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           asset_name: coder-cli-darwin-amd64.zip
           asset_content_type: application/zip
       - name: Upload Linux Release
-        id: upload-release-asset 
+        id: upload-linux-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,5 @@
 on:
   workflow_dispatch:
-    inputs:
-      preRelease:
-        description: "Pre Release"
-        required: true
-        default: "false"
-      draft:
-        description: "Draft Release"
-        required: true
-        default: "false"
 name: Create Github Release
 jobs:
   build:
@@ -43,8 +34,8 @@ jobs:
             Changes in this Release
             - First Change
             - Second Change
-          draft: ${{ github.event.inputs.draft == 'true' }}
-          prerelease: ${{ github.event.inputs.preRelease == 'true' }}
+          draft: true
+          prerelease: false
       - name: Upload Windows Release
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,11 +2,11 @@ on:
   workflow_dispatch:
     inputs:
       preRelease:
-        description: "Release channel"
+        description: "Pre Release"
         required: true
         default: "false"
       draft:
-        description: "Release channel"
+        description: "Draft Release"
         required: true
         default: "false"
 name: Create Github Release
@@ -31,5 +31,5 @@ jobs:
             Changes in this Release
             - First Change
             - Second Change
-          draft: ${{ github.event.inputs.draft == "true" }}
-          prerelease: ${{ github.event.inputs.preRelease == "true" }}
+          draft: ${{ github.event.inputs.draft == 'true' }}
+          prerelease: ${{ github.event.inputs.preRelease == 'true' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,8 @@ jobs:
           body: ""
           draft: true
           prerelease: false
-      - name: Upload Windows Release
-        id: upload-windows-release-asset 
+      - name: Upload Linux Release
+        id: upload-linux-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./ci/bin/coder-cli-linux-amd64.tar.gz
           asset_name: coder-cli-linux-amd64.tar.gz
-          asset_content_type: application/zip
+          asset_content_type: application/tar+gzip
       - name: Upload MacOS Release
         id: upload-macos-release-asset 
         uses: actions/upload-release-asset@v1
@@ -54,8 +54,8 @@ jobs:
           asset_path: ./ci/bin/coder-cli-darwin-amd64.zip
           asset_name: coder-cli-darwin-amd64.zip
           asset_content_type: application/zip
-      - name: Upload Linux Release
-        id: upload-linux-release-asset 
+      - name: Upload Windows Release
+        id: upload-windows-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+on:
+  workflow_dispatch:
+    inputs:
+      preRelease:
+        description: "Release channel"
+        required: true
+        default: "false"
+      draft:
+        description: "Release channel"
+        required: true
+        default: "false"
+name: Create Release
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      # - run: |
+      #     - git log --no-merges --pretty=format:\"- %h %s\"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Changes in this Release
+            - First Change
+            - Second Change
+          draft: ${{ github.event.inputs.draft == "true" }}
+          prerelease: ${{ github.event.inputs.preRelease == "true" }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,12 +13,24 @@ name: Create Github Release
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      # - run: |
-      #     - git log --no-merges --pretty=format:\"- %h %s\"
+      # - name: Install Gon
+      #   run: |
+      #     brew tap mitchellh/gon
+      #     brew install mitchellh/gon/gon
+      # - name: Import Signing Certificates
+      #   uses: Apple-Actions/import-codesign-certs@v1
+      #   with:
+      #     p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+      #     p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+      - name: Build Release Assets
+        run: ./ci/steps/build.sh
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -33,3 +45,33 @@ jobs:
             - Second Change
           draft: ${{ github.event.inputs.draft == 'true' }}
           prerelease: ${{ github.event.inputs.preRelease == 'true' }}
+      - name: Upload Windows Release
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ci/bin/coder-cli-linux-amd64.tar.gz
+          asset_name: coder-cli-linux-amd64.tar.gz
+          asset_content_type: application/zip
+      - name: Upload MacOS Release
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ci/bin/coder-cli-darwin-amd64.zip
+          asset_name: coder-cli-darwin-amd64.zip
+          asset_content_type: application/zip
+      - name: Upload Linux Release
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ci/bin/coder-cli-windows-386.zip
+          asset_name: coder-cli-windows-386.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
         description: "Release channel"
         required: true
         default: "false"
-name: Create Release
+name: Create Github Release
 jobs:
   build:
     name: Create Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 on:
-  workflow_dispatch:
+  push:
+    tags: "v*"
 name: Create Github Release
 jobs:
   build:
@@ -8,15 +9,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      # - name: Install Gon
-      #   run: |
-      #     brew tap mitchellh/gon
-      #     brew install mitchellh/gon/gon
-      # - name: Import Signing Certificates
-      #   uses: Apple-Actions/import-codesign-certs@v1
-      #   with:
-      #     p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
-      #     p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+      - name: Install Gon
+        run: |
+          brew tap mitchellh/gon
+          brew install mitchellh/gon/gon
+      - name: Import Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
       - name: Build Release Assets
         run: ./ci/steps/build.sh
         env:
@@ -30,10 +31,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          body: |
-            Changes in this Release
-            - First Change
-            - Second Change
+          body: ""
           draft: true
           prerelease: false
       - name: Upload Windows Release

--- a/ci/steps/build.sh
+++ b/ci/steps/build.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)/ci/steps"
 
-tag=$(git describe --tags)
+# tag=$(git describe --tags)
+tag=v1.0.0
 
 build() {
 	echo "--- building coder-cli for $GOOS-$GOARCH"

--- a/ci/steps/build.sh
+++ b/ci/steps/build.sh
@@ -30,15 +30,15 @@ build() {
 			tar -czf "$artifact" coder	
 			;;
 		"darwin")
-		if [[ ${CI-} ]]; then
-			artifact="coder-cli-$GOOS-$GOARCH.zip"
-			gon -log-level debug ./gon.json
-			mv coder.zip $artifact
-		else
+		# if [[ ${CI-} ]]; then
+		# 	artifact="coder-cli-$GOOS-$GOARCH.zip"
+		# 	gon -log-level debug ./gon.json
+		# 	mv coder.zip $artifact
+		# else
 			artifact="coder-cli-$GOOS-$GOARCH.tar.gz"
 			tar -czf "$artifact" coder	
 			echo "--- warning: not in ci, skipping signed release of darwin"
-		fi
+		# fi
 			;;
 	esac
 	popd

--- a/ci/steps/build.sh
+++ b/ci/steps/build.sh
@@ -8,8 +8,7 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)/ci/steps"
 
-# tag=$(git describe --tags)
-tag=v1.0.0
+tag=$(git describe --tags)
 
 build() {
 	echo "--- building coder-cli for $GOOS-$GOARCH"
@@ -31,15 +30,15 @@ build() {
 			tar -czf "$artifact" coder	
 			;;
 		"darwin")
-		# if [[ ${CI-} ]]; then
-		# 	artifact="coder-cli-$GOOS-$GOARCH.zip"
-		# 	gon -log-level debug ./gon.json
-		# 	mv coder.zip $artifact
-		# else
+		if [[ ${CI-} ]]; then
+			artifact="coder-cli-$GOOS-$GOARCH.zip"
+			gon -log-level debug ./gon.json
+			mv coder.zip $artifact
+		else
 			artifact="coder-cli-$GOOS-$GOARCH.tar.gz"
 			tar -czf "$artifact" coder	
 			echo "--- warning: not in ci, skipping signed release of darwin"
-		# fi
+		fi
 			;;
 	esac
 	popd


### PR DESCRIPTION
This PR adds a new Github Action workflow that runs whenever `v*` tags are pushed. It'll create a release build and upload the assets to a drafted Github release. This will still require that a human intervenes to make the release public and add any pertinent release notes. 