### PR TITLE
Use dedicated Column interface for table formatting nested structs

### DIFF
--- a/coder-sdk/env.go
+++ b/coder-sdk/env.go
@@ -54,7 +54,8 @@ type EnvironmentStat struct {
 	DiskUsed        int64             `json:"disk_used"`
 }
 
-func (e EnvironmentStat) String() string { return string(e.ContainerStatus) }
+// Column defines how EnvironmentStat should format in as a table column.
+func (e EnvironmentStat) Column() string { return string(e.ContainerStatus) }
 
 // EnvironmentStatus refers to the states of an environment.
 type EnvironmentStatus string

--- a/coder-sdk/tags.go
+++ b/coder-sdk/tags.go
@@ -18,7 +18,8 @@ type ImageTag struct {
 	CreatedAt         time.Time      `json:"created_at"           table:"-"`
 }
 
-func (i ImageTag) String() string {
+// Column defines how ImageTag should format in as a table column.
+func (i ImageTag) Column() string {
 	return i.Tag
 }
 
@@ -29,9 +30,8 @@ type OSRelease struct {
 	HomeURL    string `json:"home_url"`
 }
 
-func (o OSRelease) String() string {
-	return o.PrettyName
-}
+// Column defines how OSRelease should format in as a table column.
+func (o OSRelease) Column() string { return o.PrettyName }
 
 // CreateImageTagReq defines the request parameters for creating a new image tag.
 type CreateImageTagReq struct {

--- a/pkg/tablewriter/tablewriter.go
+++ b/pkg/tablewriter/tablewriter.go
@@ -10,6 +10,11 @@ import (
 
 const structFieldTagKey = "table"
 
+// Column defines an interface for formatting a type as a column.
+type Column interface {
+	Column() string
+}
+
 // StructValues tab delimits the values of a given struct.
 //
 // Tag a field `table:"-"` to hide it from output.
@@ -20,7 +25,12 @@ func StructValues(data interface{}) string {
 		if shouldHideField(v.Type().Field(i)) {
 			continue
 		}
-		fmt.Fprintf(s, "%v\t", v.Field(i).Interface())
+		value := v.Field(i).Interface()
+		if column, ok := value.(Column); ok {
+			fmt.Fprintf(s, "%s\t", column.Column())
+		} else {
+			fmt.Fprintf(s, "%v\t", value)
+		}
 	}
 	return s.String()
 }


### PR DESCRIPTION
For some background: we've been implementing `Stringer` to specify formatting for table columns in cases where the row has a nested struct. I realized that his may cause unexpected behavior for public consumers of `coder-sdk` when logging or otherwise formatting API types. 

This PR introduces a custom `Column` interface for specifying the format of a nested struct that should be represented as a single column. 