### PR TITLE
Migrate all API routes to /api/private

### DIFF
--- a/coder-sdk/activity.go
+++ b/coder-sdk/activity.go
@@ -12,7 +12,7 @@ type activityRequest struct {
 
 // PushActivity pushes CLI activity to Coder.
 func (c Client) PushActivity(ctx context.Context, source, envID string) error {
-	resp, err := c.request(ctx, http.MethodPost, "/api/metrics/usage/push", activityRequest{
+	resp, err := c.request(ctx, http.MethodPost, "/api/private/metrics/usage/push", activityRequest{
 		Source:        source,
 		EnvironmentID: envID,
 	})

--- a/coder-sdk/config.go
+++ b/coder-sdk/config.go
@@ -67,7 +67,7 @@ type ConfigOAuth struct {
 // SiteConfigAuth fetches the sitewide authentication configuration.
 func (c Client) SiteConfigAuth(ctx context.Context) (*ConfigAuth, error) {
 	var conf ConfigAuth
-	if err := c.requestBody(ctx, http.MethodGet, "/api/auth/config", nil, &conf); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/auth/config", nil, &conf); err != nil {
 		return nil, err
 	}
 	return &conf, nil
@@ -75,13 +75,13 @@ func (c Client) SiteConfigAuth(ctx context.Context) (*ConfigAuth, error) {
 
 // PutSiteConfigAuth sets the sitewide authentication configuration.
 func (c Client) PutSiteConfigAuth(ctx context.Context, req ConfigAuth) error {
-	return c.requestBody(ctx, http.MethodPut, "/api/auth/config", req, nil)
+	return c.requestBody(ctx, http.MethodPut, "/api/private/auth/config", req, nil)
 }
 
 // SiteConfigOAuth fetches the sitewide git provider OAuth configuration.
 func (c Client) SiteConfigOAuth(ctx context.Context) (*ConfigOAuth, error) {
 	var conf ConfigOAuth
-	if err := c.requestBody(ctx, http.MethodGet, "/api/oauth/config", nil, &conf); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/oauth/config", nil, &conf); err != nil {
 		return nil, err
 	}
 	return &conf, nil
@@ -89,7 +89,7 @@ func (c Client) SiteConfigOAuth(ctx context.Context) (*ConfigOAuth, error) {
 
 // PutSiteConfigOAuth sets the sitewide git provider OAuth configuration.
 func (c Client) PutSiteConfigOAuth(ctx context.Context, req ConfigOAuth) error {
-	return c.requestBody(ctx, http.MethodPut, "/api/oauth/config", req, nil)
+	return c.requestBody(ctx, http.MethodPut, "/api/private/oauth/config", req, nil)
 }
 
 type configSetupMode struct {
@@ -99,7 +99,7 @@ type configSetupMode struct {
 // SiteSetupModeEnabled fetches the current setup_mode state of a Coder Enterprise deployment.
 func (c Client) SiteSetupModeEnabled(ctx context.Context) (bool, error) {
 	var conf configSetupMode
-	if err := c.requestBody(ctx, http.MethodGet, "/api/config/setup-mode", nil, &conf); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/config/setup-mode", nil, &conf); err != nil {
 		return false, err
 	}
 	return conf.SetupMode, nil
@@ -127,7 +127,7 @@ type ConfigExtensionMarketplace struct {
 // SiteConfigExtensionMarketplace fetches the extension marketplace configuration.
 func (c Client) SiteConfigExtensionMarketplace(ctx context.Context) (*ConfigExtensionMarketplace, error) {
 	var conf ConfigExtensionMarketplace
-	if err := c.requestBody(ctx, http.MethodGet, "/api/extensions/config", nil, &conf); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/extensions/config", nil, &conf); err != nil {
 		return nil, err
 	}
 	return &conf, nil
@@ -135,5 +135,5 @@ func (c Client) SiteConfigExtensionMarketplace(ctx context.Context) (*ConfigExte
 
 // PutSiteConfigExtensionMarketplace sets the extension marketplace configuration.
 func (c Client) PutSiteConfigExtensionMarketplace(ctx context.Context, req ConfigExtensionMarketplace) error {
-	return c.requestBody(ctx, http.MethodPut, "/api/extensions/config", req, nil)
+	return c.requestBody(ctx, http.MethodPut, "/api/private/extensions/config", req, nil)
 }

--- a/coder-sdk/devurl.go
+++ b/coder-sdk/devurl.go
@@ -23,7 +23,7 @@ type delDevURLRequest struct {
 
 // DeleteDevURL deletes the specified devurl.
 func (c Client) DeleteDevURL(ctx context.Context, envID, urlID string) error {
-	reqURL := fmt.Sprintf("/api/environments/%s/devurls/%s", envID, urlID)
+	reqURL := fmt.Sprintf("/api/private/environments/%s/devurls/%s", envID, urlID)
 
 	return c.requestBody(ctx, http.MethodDelete, reqURL, delDevURLRequest{
 		EnvID:    envID,
@@ -42,7 +42,7 @@ type CreateDevURLReq struct {
 
 // CreateDevURL inserts a new devurl for the authenticated user.
 func (c Client) CreateDevURL(ctx context.Context, envID string, req CreateDevURLReq) error {
-	return c.requestBody(ctx, http.MethodPost, "/api/environments/"+envID+"/devurls", req, nil)
+	return c.requestBody(ctx, http.MethodPost, "/api/private/environments/"+envID+"/devurls", req, nil)
 }
 
 // PutDevURLReq defines the request parameters for overwriting a DevURL.
@@ -50,5 +50,5 @@ type PutDevURLReq CreateDevURLReq
 
 // PutDevURL updates an existing devurl for the authenticated user.
 func (c Client) PutDevURL(ctx context.Context, envID, urlID string, req PutDevURLReq) error {
-	return c.requestBody(ctx, http.MethodPut, "/api/environments/"+envID+"/devurls/"+urlID, req, nil)
+	return c.requestBody(ctx, http.MethodPut, "/api/private/environments/"+envID+"/devurls/"+urlID, req, nil)
 }

--- a/coder-sdk/env.go
+++ b/coder-sdk/env.go
@@ -83,7 +83,7 @@ type CreateEnvironmentRequest struct {
 // CreateEnvironment sends a request to create an environment.
 func (c Client) CreateEnvironment(ctx context.Context, orgID string, req CreateEnvironmentRequest) (*Environment, error) {
 	var env Environment
-	if err := c.requestBody(ctx, http.MethodPost, "/api/orgs/"+orgID+"/environments", req, &env); err != nil {
+	if err := c.requestBody(ctx, http.MethodPost, "/api/private/orgs/"+orgID+"/environments", req, &env); err != nil {
 		return nil, err
 	}
 	return &env, nil
@@ -93,7 +93,7 @@ func (c Client) CreateEnvironment(ctx context.Context, orgID string, req CreateE
 // TODO: add the filter options, explore performance issue.
 func (c Client) Environments(ctx context.Context) ([]Environment, error) {
 	var envs []Environment
-	if err := c.requestBody(ctx, http.MethodGet, "/api/environments", nil, &envs); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/environments", nil, &envs); err != nil {
 		return nil, err
 	}
 	return envs, nil
@@ -102,7 +102,7 @@ func (c Client) Environments(ctx context.Context) ([]Environment, error) {
 // EnvironmentsByOrganization gets the list of environments owned by the given user.
 func (c Client) EnvironmentsByOrganization(ctx context.Context, userID, orgID string) ([]Environment, error) {
 	var envs []Environment
-	if err := c.requestBody(ctx, http.MethodGet, "/api/orgs/"+orgID+"/members/"+userID+"/environments", nil, &envs); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs/"+orgID+"/members/"+userID+"/environments", nil, &envs); err != nil {
 		return nil, err
 	}
 	return envs, nil
@@ -110,12 +110,12 @@ func (c Client) EnvironmentsByOrganization(ctx context.Context, userID, orgID st
 
 // DeleteEnvironment deletes the environment.
 func (c Client) DeleteEnvironment(ctx context.Context, envID string) error {
-	return c.requestBody(ctx, http.MethodDelete, "/api/environments/"+envID, nil, nil)
+	return c.requestBody(ctx, http.MethodDelete, "/api/private/environments/"+envID, nil, nil)
 }
 
 // StopEnvironment stops the stops.
 func (c Client) StopEnvironment(ctx context.Context, envID string) error {
-	return c.requestBody(ctx, http.MethodPut, "/api/environments/"+envID+"/stop", nil, nil)
+	return c.requestBody(ctx, http.MethodPut, "/api/private/environments/"+envID+"/stop", nil, nil)
 }
 
 // UpdateEnvironmentReq defines the update operation, only setting
@@ -133,12 +133,12 @@ type UpdateEnvironmentReq struct {
 
 // RebuildEnvironment requests that the given envID is rebuilt with no changes to its specification.
 func (c Client) RebuildEnvironment(ctx context.Context, envID string) error {
-	return c.requestBody(ctx, http.MethodPatch, "/api/environments/"+envID, UpdateEnvironmentReq{}, nil)
+	return c.requestBody(ctx, http.MethodPatch, "/api/private/environments/"+envID, UpdateEnvironmentReq{}, nil)
 }
 
 // EditEnvironment modifies the environment specification and initiates a rebuild.
 func (c Client) EditEnvironment(ctx context.Context, envID string, req UpdateEnvironmentReq) error {
-	return c.requestBody(ctx, http.MethodPatch, "/api/environments/"+envID, req, nil)
+	return c.requestBody(ctx, http.MethodPatch, "/api/private/environments/"+envID, req, nil)
 }
 
 // DialWsep dials an environments command execution interface
@@ -163,7 +163,7 @@ func (c Client) DialIDEStatus(ctx context.Context, envID string) (*websocket.Con
 
 // DialEnvironmentBuildLog opens a websocket connection for the environment build log messages.
 func (c Client) DialEnvironmentBuildLog(ctx context.Context, envID string) (*websocket.Conn, error) {
-	return c.dialWebsocket(ctx, "/api/environments/"+envID+"/watch-update")
+	return c.dialWebsocket(ctx, "/api/private/environments/"+envID+"/watch-update")
 }
 
 // BuildLog defines a build log record for a Coder environment.
@@ -211,12 +211,12 @@ func (c Client) FollowEnvironmentBuildLog(ctx context.Context, envID string) (<-
 
 // DialEnvironmentStats opens a websocket connection for environment stats.
 func (c Client) DialEnvironmentStats(ctx context.Context, envID string) (*websocket.Conn, error) {
-	return c.dialWebsocket(ctx, "/api/environments/"+envID+"/watch-stats")
+	return c.dialWebsocket(ctx, "/api/private/environments/"+envID+"/watch-stats")
 }
 
 // DialResourceLoad opens a websocket connection for cpu load metrics on the environment.
 func (c Client) DialResourceLoad(ctx context.Context, envID string) (*websocket.Conn, error) {
-	return c.dialWebsocket(ctx, "/api/environments/"+envID+"/watch-resource-load")
+	return c.dialWebsocket(ctx, "/api/private/environments/"+envID+"/watch-resource-load")
 }
 
 // BuildLogType describes the type of an event.

--- a/coder-sdk/image.go
+++ b/coder-sdk/image.go
@@ -58,7 +58,7 @@ type UpdateImageReq struct {
 // ImportImage creates a new image and optionally a new registry.
 func (c Client) ImportImage(ctx context.Context, orgID string, req ImportImageReq) (*Image, error) {
 	var img Image
-	if err := c.requestBody(ctx, http.MethodPost, "/api/orgs/"+orgID+"/images", req, &img); err != nil {
+	if err := c.requestBody(ctx, http.MethodPost, "/api/private/orgs/"+orgID+"/images", req, &img); err != nil {
 		return nil, err
 	}
 	return &img, nil
@@ -67,7 +67,7 @@ func (c Client) ImportImage(ctx context.Context, orgID string, req ImportImageRe
 // OrganizationImages returns all of the images imported for orgID.
 func (c Client) OrganizationImages(ctx context.Context, orgID string) ([]Image, error) {
 	var imgs []Image
-	if err := c.requestBody(ctx, http.MethodGet, "/api/orgs/"+orgID+"/images", nil, &imgs); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs/"+orgID+"/images", nil, &imgs); err != nil {
 		return nil, err
 	}
 	return imgs, nil
@@ -75,5 +75,5 @@ func (c Client) OrganizationImages(ctx context.Context, orgID string) ([]Image, 
 
 // UpdateImage applies a partial update to an image resource.
 func (c Client) UpdateImage(ctx context.Context, imageID string, req UpdateImageReq) error {
-	return c.requestBody(ctx, http.MethodPatch, "/api/images/"+imageID, req, nil)
+	return c.requestBody(ctx, http.MethodPatch, "/api/private/images/"+imageID, req, nil)
 }

--- a/coder-sdk/org.go
+++ b/coder-sdk/org.go
@@ -39,7 +39,7 @@ const (
 // Organizations gets all Organizations.
 func (c Client) Organizations(ctx context.Context) ([]Organization, error) {
 	var orgs []Organization
-	if err := c.requestBody(ctx, http.MethodGet, "/api/orgs", nil, &orgs); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs", nil, &orgs); err != nil {
 		return nil, err
 	}
 	return orgs, nil
@@ -48,7 +48,7 @@ func (c Client) Organizations(ctx context.Context) ([]Organization, error) {
 // OrganizationByID get the Organization by its ID.
 func (c Client) OrganizationByID(ctx context.Context, orgID string) (*Organization, error) {
 	var org Organization
-	err := c.requestBody(ctx, http.MethodGet, "/api/orgs/"+orgID, nil, &org)
+	err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs/"+orgID, nil, &org)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c Client) OrganizationByID(ctx context.Context, orgID string) (*Organizati
 // OrganizationMembers get all members of the given organization.
 func (c Client) OrganizationMembers(ctx context.Context, orgID string) ([]OrganizationUser, error) {
 	var members []OrganizationUser
-	if err := c.requestBody(ctx, http.MethodGet, "/api/orgs/"+orgID+"/members", nil, &members); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs/"+orgID+"/members", nil, &members); err != nil {
 		return nil, err
 	}
 	return members, nil
@@ -76,7 +76,7 @@ type UpdateOrganizationReq struct {
 
 // UpdateOrganization applys a partial update of an Organization resource.
 func (c Client) UpdateOrganization(ctx context.Context, orgID string, req UpdateOrganizationReq) error {
-	return c.requestBody(ctx, http.MethodPatch, "/api/orgs/"+orgID, req, nil)
+	return c.requestBody(ctx, http.MethodPatch, "/api/private/orgs/"+orgID, req, nil)
 }
 
 // CreateOrganizationReq describes the request parameters to create a new Organization.
@@ -92,10 +92,10 @@ type CreateOrganizationReq struct {
 
 // CreateOrganization creates a new Organization in Coder Enterprise.
 func (c Client) CreateOrganization(ctx context.Context, req CreateOrganizationReq) error {
-	return c.requestBody(ctx, http.MethodPost, "/api/orgs", req, nil)
+	return c.requestBody(ctx, http.MethodPost, "/api/private/orgs", req, nil)
 }
 
 // DeleteOrganization deletes an organization.
 func (c Client) DeleteOrganization(ctx context.Context, orgID string) error {
-	return c.requestBody(ctx, http.MethodDelete, "/api/orgs/"+orgID, nil, nil)
+	return c.requestBody(ctx, http.MethodDelete, "/api/private/orgs/"+orgID, nil, nil)
 }

--- a/coder-sdk/registries.go
+++ b/coder-sdk/registries.go
@@ -19,7 +19,7 @@ type Registry struct {
 // Registries fetches all registries in an organization.
 func (c Client) Registries(ctx context.Context, orgID string) ([]Registry, error) {
 	var r []Registry
-	if err := c.requestBody(ctx, http.MethodGet, "/api/orgs/"+orgID+"/registries", nil, &r); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs/"+orgID+"/registries", nil, &r); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -28,7 +28,7 @@ func (c Client) Registries(ctx context.Context, orgID string) ([]Registry, error
 // RegistryByID fetches a registry resource by its ID.
 func (c Client) RegistryByID(ctx context.Context, orgID, registryID string) (*Registry, error) {
 	var r Registry
-	if err := c.requestBody(ctx, http.MethodGet, "/api/orgs/"+orgID+"/registries/"+registryID, nil, &r); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs/"+orgID+"/registries/"+registryID, nil, &r); err != nil {
 		return nil, err
 	}
 	return &r, nil
@@ -44,10 +44,10 @@ type UpdateRegistryReq struct {
 
 // UpdateRegistry applies a partial update to a registry resource.
 func (c Client) UpdateRegistry(ctx context.Context, orgID, registryID string, req UpdateRegistryReq) error {
-	return c.requestBody(ctx, http.MethodPatch, "/api/orgs/"+orgID+"/registries/"+registryID, req, nil)
+	return c.requestBody(ctx, http.MethodPatch, "/api/private/orgs/"+orgID+"/registries/"+registryID, req, nil)
 }
 
 // DeleteRegistry deletes a registry resource by its ID.
 func (c Client) DeleteRegistry(ctx context.Context, orgID, registryID string) error {
-	return c.requestBody(ctx, http.MethodDelete, "/api/orgs/"+orgID+"/registries/"+registryID, nil, nil)
+	return c.requestBody(ctx, http.MethodDelete, "/api/private/orgs/"+orgID+"/registries/"+registryID, nil, nil)
 }

--- a/coder-sdk/secrets.go
+++ b/coder-sdk/secrets.go
@@ -23,7 +23,7 @@ type Secret struct {
 // Deprecated: Coder Secrets will be removed from Coder Enterprise in a future release.
 func (c Client) Secrets(ctx context.Context, userID string) ([]Secret, error) {
 	var secrets []Secret
-	if err := c.requestBody(ctx, http.MethodGet, "/api/users/"+userID+"/secrets", nil, &secrets); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/users/"+userID+"/secrets", nil, &secrets); err != nil {
 		return nil, err
 	}
 	return secrets, nil
@@ -42,7 +42,7 @@ func (c Client) SecretWithValueByName(ctx context.Context, name, userID string) 
 	// NOTE: This is racy, but acceptable. If the secret is gone or the permission changed since we looked up the id,
 	//       the call will simply fail and surface the error to the user.
 	var secret Secret
-	if err := c.requestBody(ctx, http.MethodGet, "/api/users/"+userID+"/secrets/"+s.ID, nil, &secret); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/users/"+userID+"/secrets/"+s.ID, nil, &secret); err != nil {
 		return nil, err
 	}
 	return &secret, nil
@@ -53,7 +53,7 @@ func (c Client) SecretWithValueByName(ctx context.Context, name, userID string) 
 // Deprecated: Coder Secrets will be removed from Coder Enterprise in a future release.
 func (c Client) SecretWithValueByID(ctx context.Context, id, userID string) (*Secret, error) {
 	var secret Secret
-	if err := c.requestBody(ctx, http.MethodGet, "/api/users/"+userID+"/secrets/"+id, nil, &secret); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/users/"+userID+"/secrets/"+id, nil, &secret); err != nil {
 		return nil, err
 	}
 	return &secret, nil
@@ -88,7 +88,7 @@ type InsertSecretReq struct {
 //
 // Deprecated: Coder Secrets will be removed from Coder Enterprise in a future release.
 func (c Client) InsertSecret(ctx context.Context, userID string, req InsertSecretReq) error {
-	return c.requestBody(ctx, http.MethodPost, "/api/users/"+userID+"/secrets", req, nil)
+	return c.requestBody(ctx, http.MethodPost, "/api/private/users/"+userID+"/secrets", req, nil)
 }
 
 // DeleteSecretByName deletes the authenticated users secret with the given name.
@@ -103,7 +103,7 @@ func (c Client) DeleteSecretByName(ctx context.Context, name, userID string) err
 	// Delete the secret.
 	// NOTE: This is racy, but acceptable. If the secret is gone or the permission changed since we looked up the id,
 	//       the call will simply fail and surface the error to the user.
-	resp, err := c.request(ctx, http.MethodDelete, "/api/users/"+userID+"/secrets/"+secret.ID, nil)
+	resp, err := c.request(ctx, http.MethodDelete, "/api/private/users/"+userID+"/secrets/"+secret.ID, nil)
 	if err != nil {
 		return err
 	}

--- a/coder-sdk/tags.go
+++ b/coder-sdk/tags.go
@@ -42,7 +42,7 @@ type CreateImageTagReq struct {
 // CreateImageTag creates a new image tag resource.
 func (c Client) CreateImageTag(ctx context.Context, imageID string, req CreateImageTagReq) (*ImageTag, error) {
 	var tag ImageTag
-	if err := c.requestBody(ctx, http.MethodPost, "/api/images/"+imageID+"/tags", req, tag); err != nil {
+	if err := c.requestBody(ctx, http.MethodPost, "/api/private/images/"+imageID+"/tags", req, tag); err != nil {
 		return nil, err
 	}
 	return &tag, nil
@@ -50,13 +50,13 @@ func (c Client) CreateImageTag(ctx context.Context, imageID string, req CreateIm
 
 // DeleteImageTag deletes an image tag resource.
 func (c Client) DeleteImageTag(ctx context.Context, imageID, tag string) error {
-	return c.requestBody(ctx, http.MethodDelete, "/api/images/"+imageID+"/tags/"+tag, nil, nil)
+	return c.requestBody(ctx, http.MethodDelete, "/api/private/images/"+imageID+"/tags/"+tag, nil, nil)
 }
 
 // ImageTags fetch all image tags.
 func (c Client) ImageTags(ctx context.Context, imageID string) ([]ImageTag, error) {
 	var tags []ImageTag
-	if err := c.requestBody(ctx, http.MethodGet, "/api/images/"+imageID+"/tags", nil, &tags); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/images/"+imageID+"/tags", nil, &tags); err != nil {
 		return nil, err
 	}
 	return tags, nil
@@ -65,7 +65,7 @@ func (c Client) ImageTags(ctx context.Context, imageID string) ([]ImageTag, erro
 // ImageTagByID fetch an image tag by ID.
 func (c Client) ImageTagByID(ctx context.Context, imageID, tagID string) (*ImageTag, error) {
 	var tag ImageTag
-	if err := c.requestBody(ctx, http.MethodGet, "/api/images/"+imageID+"/tags/"+tagID, nil, &tag); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/images/"+imageID+"/tags/"+tagID, nil, &tag); err != nil {
 		return nil, err
 	}
 	return &tag, nil

--- a/coder-sdk/tokens.go
+++ b/coder-sdk/tokens.go
@@ -27,7 +27,7 @@ type createAPITokenResp struct {
 // CreateAPIToken creates a new APIToken for making authenticated requests to Coder Enterprise.
 func (c Client) CreateAPIToken(ctx context.Context, userID string, req CreateAPITokenReq) (token string, _ error) {
 	var resp createAPITokenResp
-	err := c.requestBody(ctx, http.MethodPost, "/api/api-keys/"+userID, req, &resp)
+	err := c.requestBody(ctx, http.MethodPost, "/api/private/api-keys/"+userID, req, &resp)
 	if err != nil {
 		return "", err
 	}
@@ -37,7 +37,7 @@ func (c Client) CreateAPIToken(ctx context.Context, userID string, req CreateAPI
 // APITokens fetches all APITokens owned by the given user.
 func (c Client) APITokens(ctx context.Context, userID string) ([]APIToken, error) {
 	var tokens []APIToken
-	if err := c.requestBody(ctx, http.MethodGet, "/api/api-keys/"+userID, nil, &tokens); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/api-keys/"+userID, nil, &tokens); err != nil {
 		return nil, err
 	}
 	return tokens, nil
@@ -46,7 +46,7 @@ func (c Client) APITokens(ctx context.Context, userID string) ([]APIToken, error
 // APITokenByID fetches the metadata for a given APIToken.
 func (c Client) APITokenByID(ctx context.Context, userID, tokenID string) (*APIToken, error) {
 	var token APIToken
-	if err := c.requestBody(ctx, http.MethodGet, "/api/api-keys/"+userID+"/"+tokenID, nil, &token); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/api-keys/"+userID+"/"+tokenID, nil, &token); err != nil {
 		return nil, err
 	}
 	return &token, nil
@@ -54,13 +54,13 @@ func (c Client) APITokenByID(ctx context.Context, userID, tokenID string) (*APIT
 
 // DeleteAPIToken deletes an APIToken.
 func (c Client) DeleteAPIToken(ctx context.Context, userID, tokenID string) error {
-	return c.requestBody(ctx, http.MethodDelete, "/api/api-keys/"+userID+"/"+tokenID, nil, nil)
+	return c.requestBody(ctx, http.MethodDelete, "/api/private/api-keys/"+userID+"/"+tokenID, nil, nil)
 }
 
 // RegenerateAPIToken regenerates the given APIToken and returns the new value.
 func (c Client) RegenerateAPIToken(ctx context.Context, userID, tokenID string) (token string, _ error) {
 	var resp createAPITokenResp
-	if err := c.requestBody(ctx, http.MethodPost, "/api/api-keys/"+userID+"/"+tokenID+"/regen", nil, &resp); err != nil {
+	if err := c.requestBody(ctx, http.MethodPost, "/api/private/api-keys/"+userID+"/"+tokenID+"/regen", nil, &resp); err != nil {
 		return "", err
 	}
 	return resp.Key, nil

--- a/coder-sdk/users.go
+++ b/coder-sdk/users.go
@@ -49,7 +49,7 @@ func (c Client) Me(ctx context.Context) (*User, error) {
 // UserByID get the details of a user by their id.
 func (c Client) UserByID(ctx context.Context, id string) (*User, error) {
 	var u User
-	if err := c.requestBody(ctx, http.MethodGet, "/api/users/"+id, nil, &u); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/users/"+id, nil, &u); err != nil {
 		return nil, err
 	}
 	return &u, nil
@@ -64,7 +64,7 @@ type SSHKey struct {
 // SSHKey gets the current SSH kepair of the authenticated user.
 func (c Client) SSHKey(ctx context.Context) (*SSHKey, error) {
 	var key SSHKey
-	if err := c.requestBody(ctx, http.MethodGet, "/api/users/me/sshkey", nil, &key); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/users/me/sshkey", nil, &key); err != nil {
 		return nil, err
 	}
 	return &key, nil
@@ -73,7 +73,7 @@ func (c Client) SSHKey(ctx context.Context) (*SSHKey, error) {
 // Users gets the list of user accounts.
 func (c Client) Users(ctx context.Context) ([]User, error) {
 	var u []User
-	if err := c.requestBody(ctx, http.MethodGet, "/api/users", nil, &u); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/users", nil, &u); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -111,7 +111,7 @@ type UpdateUserReq struct {
 
 // UpdateUser applyes the partial update to the given user.
 func (c Client) UpdateUser(ctx context.Context, userID string, req UpdateUserReq) error {
-	return c.requestBody(ctx, http.MethodPatch, "/api/users/"+userID, req, nil)
+	return c.requestBody(ctx, http.MethodPatch, "/api/private/users/"+userID, req, nil)
 }
 
 // CreateUserReq defines the request parameters for creating a new user resource.
@@ -127,10 +127,10 @@ type CreateUserReq struct {
 
 // CreateUser creates a new user account.
 func (c Client) CreateUser(ctx context.Context, req CreateUserReq) error {
-	return c.requestBody(ctx, http.MethodPost, "/api/users", req, nil)
+	return c.requestBody(ctx, http.MethodPost, "/api/private/users", req, nil)
 }
 
 // DeleteUser deletes a user account.
 func (c Client) DeleteUser(ctx context.Context, userID string) error {
-	return c.requestBody(ctx, http.MethodDelete, "/api/users/"+userID, nil, nil)
+	return c.requestBody(ctx, http.MethodDelete, "/api/private/users/"+userID, nil, nil)
 }

--- a/coder-sdk/version.go
+++ b/coder-sdk/version.go
@@ -8,7 +8,7 @@ import (
 // APIVersion parses the coder-version http header from an authenticated request.
 func (c Client) APIVersion(ctx context.Context) (string, error) {
 	const coderVersionHeaderKey = "coder-version"
-	resp, err := c.request(ctx, http.MethodGet, "/api/users/"+Me, nil)
+	resp, err := c.request(ctx, http.MethodGet, "/api/private/users/"+Me, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR migrates all routes to the new `/private` route prefix. This is part of a larger effort to standardize and release proper API documentation. Over the next several releases, we'll be migrating route groups from `/private` to `/v1` and releasing OpenAPI docs for reference.