### PR TITLE
Use default scheme of http for dev urls

### DIFF
--- a/coder-sdk/devurl.go
+++ b/coder-sdk/devurl.go
@@ -13,6 +13,7 @@ type DevURL struct {
 	Port   int    `json:"port"   table:"Port"`
 	Access string `json:"access" table:"Access"`
 	Name   string `json:"name"   table:"Name"`
+	Scheme string `json:"scheme" table:"-"`
 }
 
 type delDevURLRequest struct {
@@ -36,6 +37,7 @@ type CreateDevURLReq struct {
 	Port   int    `json:"port"`
 	Access string `json:"access"`
 	Name   string `json:"name"`
+	Scheme string `json:"scheme"`
 }
 
 // CreateDevURL inserts a new devurl for the authenticated user.

--- a/internal/cmd/urls.go
+++ b/internal/cmd/urls.go
@@ -180,6 +180,7 @@ func createDevURLCmd() *cobra.Command {
 					Name:   urlname,
 					Access: access,
 					EnvID:  env.ID,
+					Scheme: "http",
 				})
 				if err != nil {
 					return xerrors.Errorf("update DevURL: %w", err)
@@ -191,6 +192,7 @@ func createDevURLCmd() *cobra.Command {
 					Name:   urlname,
 					Access: access,
 					EnvID:  env.ID,
+					Scheme: "http",
 				})
 				if err != nil {
 					return xerrors.Errorf("insert DevURL: %w", err)


### PR DESCRIPTION
We can add a flag for specifying the scheme down the line.