### PR TITLE
cli: Update UXState from config-ssh

### DIFF
--- a/coder-sdk/users.go
+++ b/coder-sdk/users.go
@@ -114,6 +114,14 @@ func (c Client) UpdateUser(ctx context.Context, userID string, req UpdateUserReq
 	return c.requestBody(ctx, http.MethodPatch, "/api/private/users/"+userID, req, nil)
 }
 
+// UpdateUXState applies a partial update of the user's UX State.
+func (c Client) UpdateUXState(ctx context.Context, userID string, uxsPartial map[string]interface{}) error {
+	if err := c.requestBody(ctx, http.MethodPut, "/api/private/users/"+userID+"/ux-state", uxsPartial, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
 // CreateUserReq defines the request parameters for creating a new user resource.
 type CreateUserReq struct {
 	Name              string    `json:"name"`


### PR DESCRIPTION
## Context

In optimizing the dashboard environment experiences, tracking whether a user has run config-ssh locally enables personalized education about the feature.

## Testing

1. I downloaded and ran `coder config-ssh` using the binary attached to the CI run
2. I verified that my ux state was updated