### PR TITLE
Build linux/windows on ubuntu runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,18 @@ on: [push]
 
 jobs:
   build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build
+        run: make -j build/linux build/windows
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: coder-cli
+          path: ./ci/bin/coder-cli-*
+  build_darwin:
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -17,7 +29,7 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
       - name: Build
-        run: ./ci/steps/build.sh
+        run: make build/macos
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,25 @@ on:
 name: create_github_release
 jobs:
   build:
-    name: Create Release
+    name: Build binaries
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build
+        run: make -j build/linux build/windows
+      - name: Upload linux
+        uses: actions/upload-artifact@v2
+        with:
+          name: coder-cli-linux-amd64.tar.gz
+          path: ./ci/bin/coder-cli-linux-amd64.tar.gz
+      - name: Upload windows
+        uses: actions/upload-artifact@v2
+        with:
+          name: coder-cli-windows-386.tar.gz
+          path: ./ci/bin/coder-cli-windows-386.tar.gz
+  build_darwin:
+    name: Build darwin binary
     runs-on: macos-latest
     steps:
       - name: Checkout code
@@ -19,10 +37,25 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
       - name: Build Release Assets
-        run: ./ci/steps/build.sh
+        run: make build/macos
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: coder-cli-darwin-amd64.tar.gz
+          path: ./ci/bin/coder-cli-darwin-amd64.tar.gz
+  draft_release:
+    name: Create Release
+    runs-on: macos-latest
+    needs:
+      - build_darwin
+      - build
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: ./ci/bin
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,6 +53,8 @@ jobs:
       - build_darwin
       - build
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           path: ./ci/bin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,8 @@ jobs:
       - build
     steps:
       - uses: actions/download-artifact@v2
+      - name: content
+        run: sh -c "ls -al"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
           path: ./ci/bin/coder-cli-darwin-amd64.zip
   draft_release:
     name: Create Release
-    runs-on: macos-latest
+    runs-on: ubuntu-20.04
     needs:
       - build_darwin
       - build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,12 +14,12 @@ jobs:
       - name: Upload linux
         uses: actions/upload-artifact@v2
         with:
-          name: coder-cli-linux-amd64.tar.gz
+          name: coder-cli-linux-amd64
           path: ./ci/bin/coder-cli-linux-amd64.tar.gz
       - name: Upload windows
         uses: actions/upload-artifact@v2
         with:
-          name: coder-cli-windows-386.zip
+          name: coder-cli-windows-386
           path: ./ci/bin/coder-cli-windows-386.zip
   build_darwin:
     name: Build darwin binary
@@ -41,10 +41,10 @@ jobs:
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-      - name: Upload
+      - name: Upload darwin
         uses: actions/upload-artifact@v2
         with:
-          name: coder-cli-darwin-amd64.zip
+          name: coder-cli-darwin-amd64
           path: ./ci/bin/coder-cli-darwin-amd64.zip
   draft_release:
     name: Create Release
@@ -74,7 +74,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: coder-cli-linux-amd64.tar.gz
+          asset_path: coder-cli-linux-amd64/coder-cli-linux-amd64.tar.gz
           asset_name: coder-cli-linux-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload MacOS Release
@@ -84,7 +84,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: coder-cli-darwin-amd64.zip
+          asset_path: coder-cli-darwin-amd64/coder-cli-darwin-amd64.zip
           asset_name: coder-cli-darwin-amd64.zip
           asset_content_type: application/zip
       - name: Upload Windows Release
@@ -94,6 +94,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: coder-cli-windows-386.zip
+          asset_path: coder-cli-windows-386/coder-cli-windows-386.zip
           asset_name: coder-cli-windows-386.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,11 +53,7 @@ jobs:
       - build_darwin
       - build
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
-        with:
-          path: ./ci/bin
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -76,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./ci/bin/coder-cli-linux-amd64.tar.gz
+          asset_path: coder-cli-linux-amd64.tar.gz
           asset_name: coder-cli-linux-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload MacOS Release
@@ -86,7 +82,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./ci/bin/coder-cli-darwin-amd64.zip
+          asset_path: coder-cli-darwin-amd64.zip
           asset_name: coder-cli-darwin-amd64.zip
           asset_content_type: application/zip
       - name: Upload Windows Release
@@ -96,6 +92,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./ci/bin/coder-cli-windows-386.zip
+          asset_path: coder-cli-windows-386.zip
           asset_name: coder-cli-windows-386.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,8 @@ jobs:
       - name: Upload windows
         uses: actions/upload-artifact@v2
         with:
-          name: coder-cli-windows-386.tar.gz
-          path: ./ci/bin/coder-cli-windows-386.tar.gz
+          name: coder-cli-windows-386.zip
+          path: ./ci/bin/coder-cli-windows-386.zip
   build_darwin:
     name: Build darwin binary
     runs-on: macos-latest
@@ -44,8 +44,8 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: coder-cli-darwin-amd64.tar.gz
-          path: ./ci/bin/coder-cli-darwin-amd64.tar.gz
+          name: coder-cli-darwin-amd64.zip
+          path: ./ci/bin/coder-cli-darwin-amd64.zip
   draft_release:
     name: Create Release
     runs-on: macos-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# Makefile for Coder CLI 
+
+.PHONY: clean build/macos build/windows build/linux
+
+clean:
+	rm -rf ./ci/bin
+
+build/macos:
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 ./ci/steps/build.sh
+build/windows:
+	CGO_ENABLED=0 GOOS=windows GOARCH=386 ./ci/steps/build.sh
+build/linux:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ./ci/steps/build.sh
+

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 # Makefile for Coder CLI 
 
-.PHONY: clean build/macos build/windows build/linux
+.PHONY: clean build build/macos build/windows build/linux
 
 clean:
 	rm -rf ./ci/bin
 
+build: build/macos build/windows build/linux
+
 build/macos:
+	# requires darwin
 	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 ./ci/steps/build.sh
 build/windows:
 	CGO_ENABLED=0 GOOS=windows GOARCH=386 ./ci/steps/build.sh
 build/linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ./ci/steps/build.sh
-

--- a/ci/integration/Dockerfile
+++ b/ci/integration/Dockerfile
@@ -1,3 +1,3 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y jq curl
+RUN apt-get update && apt-get install -y jq curl build-essential

--- a/ci/integration/setup_test.go
+++ b/ci/integration/setup_test.go
@@ -37,7 +37,7 @@ func build(path string) error {
 	cmd := exec.Command(
 		"sh", "-c",
 		fmt.Sprintf(
-			"cd ../../ && mkdir -p %s && ./ci/steps/build.sh && cp ./ci/bin/%s %s/ && tar -xzf %s -C %s",
+			"cd ../../ && mkdir -p %s && make build/linux && cp ./ci/bin/%s %s/ && tar -xzf %s -C %s",
 			dir, tar, dir, filepath.Join(dir, tar), dir),
 	)
 

--- a/ci/steps/build.sh
+++ b/ci/steps/build.sh
@@ -10,52 +10,38 @@ cd "$(git rev-parse --show-toplevel)/ci/steps"
 
 tag=$(git describe --tags)
 
-build() {
-	echo "--- building coder-cli for $GOOS-$GOARCH"
+echo "--- building coder-cli for $GOOS-$GOARCH"
 
-	tmpdir=$(mktemp -d)
-	go build -ldflags "-X cdr.dev/coder-cli/internal/version.Version=${tag}" -o "$tmpdir/coder" ../../cmd/coder
-	# For MacOS builds to be notarized.
-	cp ../gon.json $tmpdir/gon.json
+tmpdir=$(mktemp -d)
+go build -ldflags "-X cdr.dev/coder-cli/internal/version.Version=${tag}" -o "$tmpdir/coder" ../../cmd/coder
 
-	pushd "$tmpdir"
-	case "$GOOS" in
-		"windows")
-			artifact="coder-cli-$GOOS-$GOARCH.zip"
-			mv coder coder.exe
-			zip "$artifact" coder.exe
-			;;
-		"linux")
-			artifact="coder-cli-$GOOS-$GOARCH.tar.gz"
-			tar -czf "$artifact" coder	
-			;;
-		"darwin")
-		if [[ ${CI-} ]]; then
-			artifact="coder-cli-$GOOS-$GOARCH.zip"
-			gon -log-level debug ./gon.json
-			mv coder.zip $artifact
-		else
-			artifact="coder-cli-$GOOS-$GOARCH.tar.gz"
-			tar -czf "$artifact" coder	
-			echo "--- warning: not in ci, skipping signed release of darwin"
-		fi
-			;;
-	esac
-	popd
+cp ../gon.json $tmpdir/gon.json
 
-	mkdir -p ../bin
-	cp "$tmpdir/$artifact" ../bin/$artifact
-	rm -rf "$tmpdir"
-}
+pushd "$tmpdir"
+case "$GOOS" in
+"windows")
+	artifact="coder-cli-$GOOS-$GOARCH.zip"
+	mv coder coder.exe
+	zip "$artifact" coder.exe
+	;;
+"linux")
+	artifact="coder-cli-$GOOS-$GOARCH.tar.gz"
+	tar -czf "$artifact" coder
+	;;
+"darwin")
+	if [[ ${CI-} ]]; then
+		artifact="coder-cli-$GOOS-$GOARCH.zip"
+		gon -log-level debug ./gon.json
+		mv coder.zip $artifact
+	else
+		artifact="coder-cli-$GOOS-$GOARCH.tar.gz"
+		tar -czf "$artifact" coder
+		echo "--- warning: not in ci, skipping signed release of darwin"
+	fi
+	;;
+esac
+popd
 
-# Darwin builds do not work from Linux, so only try to build them from Darwin.
-# See: https://github.com/cdr/coder-cli/issues/20
-if [[ "$(uname)" == "Darwin" ]]; then
-	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 build
-else
-	echo "--- warning: Darwin builds don't work on Linux."
-	echo "--- please use an OSX machine to build Darwin tars."
-fi
-
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 build
-GOOS=windows GOARCH=386 build
+mkdir -p ../bin
+cp "$tmpdir/$artifact" ../bin/$artifact
+rm -rf "$tmpdir"

--- a/pkg/tcli/tcli.go
+++ b/pkg/tcli/tcli.go
@@ -67,7 +67,7 @@ func NewContainerRunner(ctx context.Context, config *ContainerConfig) (*Containe
 		"run",
 		"--name", config.Name,
 		"--network", "host",
-		"-it", "-d",
+		"--rm", "-it", "-d",
 	}
 	args = append(args, mountArgs(config.BindMounts)...)
 	args = append(args, config.Image)


### PR DESCRIPTION
This PR modifies the build process to use an ubuntu runner for windows/linux binary compilation. This fixes some Windows Defender issues caused by macOS go cross compilation. 