### PR TITLE
Remove --user flag from "envs create"

### DIFF
--- a/docs/coder_envs.md
+++ b/docs/coder_envs.md
@@ -9,8 +9,7 @@ Perform operations on the Coder environments owned by the active user.
 ### Options
 
 ```
-  -h, --help          help for envs
-      --user string   Specify the user whose resources to target (default "me")
+  -h, --help   help for envs
 ```
 
 ### Options inherited from parent commands

--- a/docs/coder_envs_create.md
+++ b/docs/coder_envs_create.md
@@ -36,8 +36,7 @@ coder envs create my-new-powerful-env --cpu 12 --disk 100 --memory 16 --image ub
 ### Options inherited from parent commands
 
 ```
-      --user string   Specify the user whose resources to target (default "me")
-  -v, --verbose       show verbose output
+  -v, --verbose   show verbose output
 ```
 
 ### SEE ALSO

--- a/docs/coder_envs_edit.md
+++ b/docs/coder_envs_edit.md
@@ -32,13 +32,13 @@ coder envs edit back-end-env --disk 20
       --not-container-vm   do not deploy the environment as a Container-based VM
   -o, --org string         name of the organization the environment should be created under.
   -t, --tag string         image tag of the image you want to base the environment off of. (default "latest")
+      --user string        Specify the user whose resources to target (default "me")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --user string   Specify the user whose resources to target (default "me")
-  -v, --verbose       show verbose output
+  -v, --verbose   show verbose output
 ```
 
 ### SEE ALSO

--- a/docs/coder_envs_ls.md
+++ b/docs/coder_envs_ls.md
@@ -15,13 +15,13 @@ coder envs ls [flags]
 ```
   -h, --help            help for ls
   -o, --output string   human | json (default "human")
+      --user string     Specify the user whose resources to target (default "me")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --user string   Specify the user whose resources to target (default "me")
-  -v, --verbose       show verbose output
+  -v, --verbose   show verbose output
 ```
 
 ### SEE ALSO

--- a/docs/coder_envs_rebuild.md
+++ b/docs/coder_envs_rebuild.md
@@ -16,16 +16,16 @@ coder envs rebuild backend-env --force
 ### Options
 
 ```
-      --follow   follow build log after initiating rebuild
-      --force    force rebuild without showing a confirmation prompt
-  -h, --help     help for rebuild
+      --follow        follow build log after initiating rebuild
+      --force         force rebuild without showing a confirmation prompt
+  -h, --help          help for rebuild
+      --user string   Specify the user whose resources to target (default "me")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --user string   Specify the user whose resources to target (default "me")
-  -v, --verbose       show verbose output
+  -v, --verbose   show verbose output
 ```
 
 ### SEE ALSO

--- a/docs/coder_envs_rm.md
+++ b/docs/coder_envs_rm.md
@@ -9,15 +9,15 @@ coder envs rm [...environment_names] [flags]
 ### Options
 
 ```
-  -f, --force   force remove the specified environments without prompting first
-  -h, --help    help for rm
+  -f, --force         force remove the specified environments without prompting first
+  -h, --help          help for rm
+      --user string   Specify the user whose resources to target (default "me")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --user string   Specify the user whose resources to target (default "me")
-  -v, --verbose       show verbose output
+  -v, --verbose   show verbose output
 ```
 
 ### SEE ALSO

--- a/docs/coder_envs_stop.md
+++ b/docs/coder_envs_stop.md
@@ -28,14 +28,14 @@ coder envs --user charlie@coder.com ls -o json \
 ### Options
 
 ```
-  -h, --help   help for stop
+  -h, --help          help for stop
+      --user string   Specify the user whose resources to target (default "me")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --user string   Specify the user whose resources to target (default "me")
-  -v, --verbose       show verbose output
+  -v, --verbose   show verbose output
 ```
 
 ### SEE ALSO

--- a/docs/coder_envs_watch-build.md
+++ b/docs/coder_envs_watch-build.md
@@ -15,14 +15,14 @@ coder envs watch-build front-end-env
 ### Options
 
 ```
-  -h, --help   help for watch-build
+  -h, --help          help for watch-build
+      --user string   Specify the user whose resources to target (default "me")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --user string   Specify the user whose resources to target (default "me")
-  -v, --verbose       show verbose output
+  -v, --verbose   show verbose output
 ```
 
 ### SEE ALSO

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -17,9 +17,10 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func rebuildEnvCommand(user *string) *cobra.Command {
+func rebuildEnvCommand() *cobra.Command {
 	var follow bool
 	var force bool
+	var user string
 	cmd := &cobra.Command{
 		Use:   "rebuild [environment_name]",
 		Short: "rebuild a Coder environment",
@@ -32,7 +33,7 @@ coder envs rebuild backend-env --force`,
 			if err != nil {
 				return err
 			}
-			env, err := findEnv(ctx, client, args[0], *user)
+			env, err := findEnv(ctx, client, args[0], user)
 			if err != nil {
 				return err
 			}
@@ -67,6 +68,7 @@ coder envs rebuild backend-env --force`,
 		},
 	}
 
+	cmd.Flags().StringVar(&user, "user", coder.Me, "Specify the user whose resources to target")
 	cmd.Flags().BoolVar(&follow, "follow", false, "follow build log after initiating rebuild")
 	cmd.Flags().BoolVar(&force, "force", false, "force rebuild without showing a confirmation prompt")
 	return cmd
@@ -136,7 +138,8 @@ func trailBuildLogs(ctx context.Context, client *coder.Client, envID string) err
 	return nil
 }
 
-func watchBuildLogCommand(user *string) *cobra.Command {
+func watchBuildLogCommand() *cobra.Command {
+	var user string
 	cmd := &cobra.Command{
 		Use:     "watch-build [environment_name]",
 		Example: "coder envs watch-build front-end-env",
@@ -148,7 +151,7 @@ func watchBuildLogCommand(user *string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			env, err := findEnv(ctx, client, args[0], *user)
+			env, err := findEnv(ctx, client, args[0], user)
 			if err != nil {
 				return err
 			}
@@ -159,5 +162,6 @@ func watchBuildLogCommand(user *string) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&user, "user", coder.Me, "Specify the user whose resources to target")
 	return cmd
 }


### PR DESCRIPTION
This PR removes the persistent --user flag from the `coder envs create` command.