### PR TITLE
chore: update API routes for images/registries

### DIFF
--- a/ci/integration/envs_test.go
+++ b/ci/integration/envs_test.go
@@ -81,8 +81,9 @@ search:
 	}
 	if !found {
 		// ignore this error for now as it causes a race with other parallel tests
-		_, _ = client.ImportImage(ctx, org.ID, coder.ImportImageReq{
+		_, _ = client.ImportImage(ctx, coder.ImportImageReq{
 			RegistryID:      &dockerhubID,
+			OrgID:           org.ID,
 			Repository:      img,
 			Tag:             "latest",
 			DefaultCPUCores: 2.5,

--- a/coder-sdk/registries.go
+++ b/coder-sdk/registries.go
@@ -3,6 +3,7 @@ package coder
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -18,17 +19,23 @@ type Registry struct {
 
 // Registries fetches all registries in an organization.
 func (c Client) Registries(ctx context.Context, orgID string) ([]Registry, error) {
-	var r []Registry
-	if err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs/"+orgID+"/registries", nil, &r); err != nil {
+	var (
+		r     []Registry
+		query = url.Values{}
+	)
+
+	query.Set("org", orgID)
+
+	if err := c.requestBody(ctx, http.MethodGet, "/api/v0/registries", nil, &r, withQueryParams(query)); err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 
 // RegistryByID fetches a registry resource by its ID.
-func (c Client) RegistryByID(ctx context.Context, orgID, registryID string) (*Registry, error) {
+func (c Client) RegistryByID(ctx context.Context, registryID string) (*Registry, error) {
 	var r Registry
-	if err := c.requestBody(ctx, http.MethodGet, "/api/private/orgs/"+orgID+"/registries/"+registryID, nil, &r); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/v0/registries/"+registryID, nil, &r); err != nil {
 		return nil, err
 	}
 	return &r, nil
@@ -43,11 +50,11 @@ type UpdateRegistryReq struct {
 }
 
 // UpdateRegistry applies a partial update to a registry resource.
-func (c Client) UpdateRegistry(ctx context.Context, orgID, registryID string, req UpdateRegistryReq) error {
-	return c.requestBody(ctx, http.MethodPatch, "/api/private/orgs/"+orgID+"/registries/"+registryID, req, nil)
+func (c Client) UpdateRegistry(ctx context.Context, registryID string, req UpdateRegistryReq) error {
+	return c.requestBody(ctx, http.MethodPatch, "/api/v0/registries/"+registryID, req, nil)
 }
 
 // DeleteRegistry deletes a registry resource by its ID.
-func (c Client) DeleteRegistry(ctx context.Context, orgID, registryID string) error {
-	return c.requestBody(ctx, http.MethodDelete, "/api/private/orgs/"+orgID+"/registries/"+registryID, nil, nil)
+func (c Client) DeleteRegistry(ctx context.Context, registryID string) error {
+	return c.requestBody(ctx, http.MethodDelete, "/api/v0/registries/"+registryID, nil, nil)
 }


### PR DESCRIPTION
- This is part of an ongoing effort to standardize
  our API for public consumption. This fixes some routes
  that broke backwards compatibility (specifically
  image and registry routes).