### PR TITLE
feat: Prompt user to rebuild workspace on coder sh

### DIFF
--- a/coder-sdk/env.go
+++ b/coder-sdk/env.go
@@ -274,3 +274,12 @@ func (c Client) WaitForEnvironmentReady(ctx context.Context, envID string) error
 		}
 	}
 }
+
+// EnvironmentByID get the details of an environment by its id.
+func (c Client) EnvironmentByID(ctx context.Context, id string) (*Environment, error) {
+	var env Environment
+	if err := c.requestBody(ctx, http.MethodGet, "/api/v0/environments/"+id, nil, &env); err != nil {
+		return nil, err
+	}
+	return &env, nil
+}

--- a/docs/coder_sh.md
+++ b/docs/coder_sh.md
@@ -4,7 +4,9 @@ Open a shell and execute commands in a Coder environment
 
 ### Synopsis
 
-Execute a remote command on the environment\nIf no command is specified, the default shell is opened.
+Execute a remote command on the environment
+If no command is specified, the default shell is opened.
+If the command is run in an interactive shell, a user prompt will occur if the environment needs to be rebuilt.
 
 ```
 coder sh [environment_name] [<command [args...]>] [flags]


### PR DESCRIPTION
## Quality of Life Feature

When a user does `coder sh <env>`, the cli first checks if that environment is `OFF` or if it requires a rebuild before using. It will then prompt the user if they want to rebuild the workspace.

## To test

**Off**
```
coder env stop <workspace>
coder sh <workspace>
```

**Rebuild Message**

If the environment has a required rebuild message, the output looks like this:
![Screenshot from 2021-01-21 16-22-16](https://user-images.githubusercontent.com/5446298/105419772-db12d080-5c04-11eb-84ac-5ae0fcdebbe8.png)


## Questions:

Currently `--force` does not work for this feature, and there is no `--no-rebuild` flag. The current command has flag parsing disabled. Are these kinds of flags required? I imagine a user prompt would make scripting `coder sh` rather annoying.

