### PR TITLE
Create login shell with coder sh

### DIFF
--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -85,7 +85,9 @@ func shell(cmd *cobra.Command, cmdArgs []string) error {
 		args = append(args, strings.Join(cmdArgs[1:], " "))
 	} else {
 		// Bring user into shell if no command is specified.
-		args = append(args, "exec $(getent passwd $(whoami) | awk -F: '{ print $7 }')")
+		shell := "$(getent passwd $(id -u) | cut -d: -f 7)"
+		name := "-$(basename " + shell + ")"
+		args = append(args, fmt.Sprintf("exec -a %q %q", name, shell))
 	}
 
 	envName := cmdArgs[0]


### PR DESCRIPTION
When creating a shell, we should use "exec -a" to set argv[0]
to the basename of the command being run, prefixing a hyphen.
This is how su --login creates login shells: it runs /bin/bash
as "-bash", causing bash to execute .bash_profile, etc.

We change the use of awk to cut, since cut is part of coreutils
and thus more likely to be installed than gawk. We also pass the
uid (from "id -u") instead of username to getent.