### PR TITLE
feat: improved arg usage errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cdr.dev/slog v1.3.0
 	cdr.dev/wsep v0.0.0-20200728013649-82316a09813f
 	github.com/briandowns/spinner v1.11.1
-	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.9.0
 	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cdr.dev/slog v1.3.0
 	cdr.dev/wsep v0.0.0-20200728013649-82316a09813f
 	github.com/briandowns/spinner v1.11.1
+	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.9.0
 	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/websocket v1.4.2

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -46,8 +46,8 @@ func genDocsCmd(rootCmd *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:     "gen-docs [dir_path]",
 		Short:   "Generate a markdown documentation tree for the root command.",
+		Args:    xcobra.ExactArgs(1),
 		Example: "coder gen-docs ./docs",
-		Args:    xcobra.ExactArgs(1, "dir_path"),
 		Hidden:  true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return doc.GenMarkdownTree(rootCmd, args[0])

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"os"
 
+	"cdr.dev/coder-cli/internal/x/xcobra"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -46,7 +47,7 @@ func genDocsCmd(rootCmd *cobra.Command) *cobra.Command {
 		Use:     "gen-docs [dir_path]",
 		Short:   "Generate a markdown documentation tree for the root command.",
 		Example: "coder gen-docs ./docs",
-		Args:    cobra.ExactArgs(1),
+		Args:    xcobra.ExactArgs(1, "dir_path"),
 		Hidden:  true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return doc.GenMarkdownTree(rootCmd, args[0])

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -160,7 +160,7 @@ func createEnvCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [environment_name]",
 		Short: "create a new environment.",
-		Args:  xcobra.ExactArgs(1, "environment_name"),
+		Args:  xcobra.ExactArgs(1),
 		Long:  "Create a new Coder environment.",
 		Example: `# create a new environment using default resource amounts
 coder envs create my-new-env --image ubuntu
@@ -268,7 +268,7 @@ func editEnvCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "edit an existing environment and initiate a rebuild.",
-		Args:  xcobra.ExactArgs(1, "environment_name"),
+		Args:  xcobra.ExactArgs(1),
 		Long:  "Edit an existing environment and initate a rebuild.",
 		Example: `coder envs edit back-end-env --cpu 4
 

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/x/xcobra"
 	"cdr.dev/coder-cli/pkg/clog"
 	"cdr.dev/coder-cli/pkg/tablewriter"
 
@@ -159,7 +160,7 @@ func createEnvCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [environment_name]",
 		Short: "create a new environment.",
-		Args:  cobra.ExactArgs(1),
+		Args:  xcobra.ExactArgs(1, "environment_name"),
 		Long:  "Create a new Coder environment.",
 		Example: `# create a new environment using default resource amounts
 coder envs create my-new-env --image ubuntu
@@ -267,7 +268,7 @@ func editEnvCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "edit an existing environment and initiate a rebuild.",
-		Args:  cobra.ExactArgs(1),
+		Args:  xcobra.ExactArgs(1, "environment_name"),
 		Long:  "Edit an existing environment and initate a rebuild.",
 		Example: `coder envs edit back-end-env --cpu 4
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -12,6 +12,7 @@ import (
 	"cdr.dev/coder-cli/internal/config"
 	"cdr.dev/coder-cli/internal/loginsrv"
 	"cdr.dev/coder-cli/internal/version"
+	"cdr.dev/coder-cli/internal/x/xcobra"
 	"cdr.dev/coder-cli/pkg/clog"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -23,7 +24,7 @@ func loginCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "login [Coder Enterprise URL eg. https://my.coder.domain/]",
 		Short: "Authenticate this client for future operations",
-		Args:  cobra.ExactArgs(1),
+		Args:  xcobra.ExactArgs(1, "access_url"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Pull the URL from the args and do some sanity check.
 			rawURL := args[0]

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -24,7 +24,7 @@ func loginCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "login [Coder Enterprise URL eg. https://my.coder.domain/]",
 		Short: "Authenticate this client for future operations",
-		Args:  xcobra.ExactArgs(1, "access_url"),
+		Args:  xcobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Pull the URL from the args and do some sanity check.
 			rawURL := args[0]

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/x/xcobra"
 	"cdr.dev/coder-cli/pkg/clog"
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
@@ -24,7 +25,7 @@ func rebuildEnvCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rebuild [environment_name]",
 		Short: "rebuild a Coder environment",
-		Args:  cobra.ExactArgs(1),
+		Args:  xcobra.ExactArgs(1, "environment_name"),
 		Example: `coder envs rebuild front-end-env --follow
 coder envs rebuild backend-env --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -144,7 +145,7 @@ func watchBuildLogCommand() *cobra.Command {
 		Use:     "watch-build [environment_name]",
 		Example: "coder envs watch-build front-end-env",
 		Short:   "trail the build log of a Coder environment",
-		Args:    cobra.ExactArgs(1),
+		Args:    xcobra.ExactArgs(1, "environment_name"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -25,7 +25,7 @@ func rebuildEnvCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rebuild [environment_name]",
 		Short: "rebuild a Coder environment",
-		Args:  xcobra.ExactArgs(1, "environment_name"),
+		Args:  xcobra.ExactArgs(1),
 		Example: `coder envs rebuild front-end-env --follow
 coder envs rebuild backend-env --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -145,7 +145,7 @@ func watchBuildLogCommand() *cobra.Command {
 		Use:     "watch-build [environment_name]",
 		Example: "coder envs watch-build front-end-env",
 		Short:   "trail the build log of a Coder environment",
-		Args:    xcobra.ExactArgs(1, "environment_name"),
+		Args:    xcobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -10,6 +10,7 @@ import (
 
 	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/coder-cli/internal/sync"
+	"cdr.dev/coder-cli/internal/x/xcobra"
 	"cdr.dev/coder-cli/pkg/clog"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -20,7 +21,7 @@ func syncCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync [local directory] [<env name>:<remote directory>]",
 		Short: "Establish a one way directory sync to a Coder environment",
-		Args:  cobra.ExactArgs(2),
+		Args:  xcobra.ExactArgs(2, "local_director", "<env_name>:<remote_dir>"),
 		RunE:  makeRunSync(&init),
 	}
 	cmd.Flags().BoolVar(&init, "init", false, "do initial transfer and exit")

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -21,7 +21,7 @@ func syncCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync [local directory] [<env name>:<remote directory>]",
 		Short: "Establish a one way directory sync to a Coder environment",
-		Args:  xcobra.ExactArgs(2, "local_director", "<env_name>:<remote_dir>"),
+		Args:  xcobra.ExactArgs(2),
 		RunE:  makeRunSync(&init),
 	}
 	cmd.Flags().BoolVar(&init, "init", false, "do initial transfer and exit")

--- a/internal/cmd/tags.go
+++ b/internal/cmd/tags.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/x/xcobra"
 	"cdr.dev/coder-cli/pkg/clog"
 	"cdr.dev/coder-cli/pkg/tablewriter"
 	"github.com/spf13/cobra"
@@ -37,7 +38,7 @@ func tagsCreateCmd() *cobra.Command {
 		Short:   "add an image tag",
 		Long:    "allow users to create environments with this image tag",
 		Example: `coder tags create latest --image ubuntu --org default`,
-		Args:    cobra.ExactArgs(1),
+		Args:    xcobra.ExactArgs(1, "tag"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)
@@ -139,7 +140,7 @@ func tagsRmCmd() *cobra.Command {
 		Use:     "rm [tag]",
 		Short:   "remove an image tag",
 		Example: `coder tags rm latest --image ubuntu --org default`,
-		Args:    cobra.ExactArgs(1),
+		Args:    xcobra.ExactArgs(1, "tag"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)

--- a/internal/cmd/tags.go
+++ b/internal/cmd/tags.go
@@ -38,7 +38,7 @@ func tagsCreateCmd() *cobra.Command {
 		Short:   "add an image tag",
 		Long:    "allow users to create environments with this image tag",
 		Example: `coder tags create latest --image ubuntu --org default`,
-		Args:    xcobra.ExactArgs(1, "tag"),
+		Args:    xcobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)
@@ -140,7 +140,7 @@ func tagsRmCmd() *cobra.Command {
 		Use:     "rm [tag]",
 		Short:   "remove an image tag",
 		Example: `coder tags rm latest --image ubuntu --org default`,
-		Args:    xcobra.ExactArgs(1, "tag"),
+		Args:    xcobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -56,7 +56,7 @@ func createTokensCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "create [token_name]",
 		Short: "create generates a new API token and prints it to stdout",
-		Args:  xcobra.ExactArgs(1, "token_name"),
+		Args:  xcobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)
@@ -79,7 +79,7 @@ func rmTokenCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "rm [token_id]",
 		Short: "remove an API token by its unique ID",
-		Args:  xcobra.ExactArgs(1, "token_id"),
+		Args:  xcobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)
@@ -98,7 +98,7 @@ func regenTokenCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "regen [token_id]",
 		Short: "regenerate an API token by its unique ID and print the new token to stdout",
-		Args:  xcobra.ExactArgs(1, "token_id"),
+		Args:  xcobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/x/xcobra"
 	"cdr.dev/coder-cli/pkg/tablewriter"
 	"github.com/spf13/cobra"
 )
@@ -55,7 +56,7 @@ func createTokensCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "create [token_name]",
 		Short: "create generates a new API token and prints it to stdout",
-		Args:  cobra.ExactArgs(1),
+		Args:  xcobra.ExactArgs(1, "token_name"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)
@@ -78,7 +79,7 @@ func rmTokenCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "rm [token_id]",
 		Short: "remove an API token by its unique ID",
-		Args:  cobra.ExactArgs(1),
+		Args:  xcobra.ExactArgs(1, "token_id"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)
@@ -97,7 +98,7 @@ func regenTokenCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "regen [token_id]",
 		Short: "regenerate an API token by its unique ID and print the new token to stdout",
-		Args:  cobra.ExactArgs(1),
+		Args:  xcobra.ExactArgs(1, "token_id"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)

--- a/internal/cmd/urls.go
+++ b/internal/cmd/urls.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/x/xcobra"
 	"cdr.dev/coder-cli/pkg/clog"
 	"cdr.dev/coder-cli/pkg/tablewriter"
 )
@@ -26,7 +27,7 @@ func urlCmd() *cobra.Command {
 	lsCmd := &cobra.Command{
 		Use:               "ls [environment_name]",
 		Short:             "List all DevURLs for an environment",
-		Args:              cobra.ExactArgs(1),
+		Args:              xcobra.ExactArgs(1, "environment_name"),
 		ValidArgsFunction: getEnvsForCompletion(coder.Me),
 		RunE:              listDevURLsCmd(&outputFmt),
 	}
@@ -126,7 +127,7 @@ func createDevURLCmd() *cobra.Command {
 		Use:     "create [env_name] [port]",
 		Short:   "Create a new devurl for an environment",
 		Aliases: []string{"edit"},
-		Args:    cobra.ExactArgs(2),
+		Args:    xcobra.ExactArgs(2, "environment_name", "port"),
 		// Run creates or updates a devURL
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (

--- a/internal/cmd/urls.go
+++ b/internal/cmd/urls.go
@@ -27,7 +27,7 @@ func urlCmd() *cobra.Command {
 	lsCmd := &cobra.Command{
 		Use:               "ls [environment_name]",
 		Short:             "List all DevURLs for an environment",
-		Args:              xcobra.ExactArgs(1, "environment_name"),
+		Args:              xcobra.ExactArgs(1),
 		ValidArgsFunction: getEnvsForCompletion(coder.Me),
 		RunE:              listDevURLsCmd(&outputFmt),
 	}
@@ -127,7 +127,7 @@ func createDevURLCmd() *cobra.Command {
 		Use:     "create [env_name] [port]",
 		Short:   "Create a new devurl for an environment",
 		Aliases: []string{"edit"},
-		Args:    xcobra.ExactArgs(2, "environment_name", "port"),
+		Args:    xcobra.ExactArgs(2),
 		// Run creates or updates a devURL
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (

--- a/internal/x/xcobra/cobra.go
+++ b/internal/x/xcobra/cobra.go
@@ -3,7 +3,6 @@ package xcobra
 
 import (
 	"fmt"
-	"strings"
 
 	"cdr.dev/coder-cli/pkg/clog"
 	"github.com/fatih/color"
@@ -11,21 +10,12 @@ import (
 )
 
 // ExactArgs returns an error if there are not exactly n args.
-func ExactArgs(n int, names ...string) cobra.PositionalArgs {
-	wrap := func(name string) string { return fmt.Sprintf("[%s]", name) }
+func ExactArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		wrappedNames := make([]string, 0, len(names))
 		if len(args) != n {
-			for _, name := range names {
-				wrappedNames = append(wrappedNames, wrap(name))
-			}
-			baseMsg := fmt.Sprintf("accepts %d arg(s), received %d", n, len(args))
-			if len(names) == 0 {
-				return clog.Error(baseMsg)
-			}
 			return clog.Error(
-				baseMsg,
-				color.New(color.Bold).Sprintf("args: ")+strings.Join(wrappedNames, " "),
+				fmt.Sprintf("accepts %d arg(s), received %d", n, len(args)),
+				color.New(color.Bold).Sprintf("usage: ")+cmd.UseLine(),
 				clog.BlankLine,
 				clog.Tipf("use \"--help\" for more info"),
 			)

--- a/internal/x/xcobra/cobra.go
+++ b/internal/x/xcobra/cobra.go
@@ -1,0 +1,35 @@
+// Package xcobra wraps the cobra package to provide richer functionality.
+package xcobra
+
+import (
+	"fmt"
+	"strings"
+
+	"cdr.dev/coder-cli/pkg/clog"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// ExactArgs returns an error if there are not exactly n args.
+func ExactArgs(n int, names ...string) cobra.PositionalArgs {
+	wrap := func(name string) string { return fmt.Sprintf("[%s]", name) }
+	return func(cmd *cobra.Command, args []string) error {
+		wrappedNames := make([]string, 0, len(names))
+		if len(args) != n {
+			for _, name := range names {
+				wrappedNames = append(wrappedNames, wrap(name))
+			}
+			baseMsg := fmt.Sprintf("accepts %d arg(s), received %d", n, len(args))
+			if len(names) == 0 {
+				return clog.Error(baseMsg)
+			}
+			return clog.Error(
+				baseMsg,
+				color.New(color.Bold).Sprintf("args: ")+strings.Join(wrappedNames, " "),
+				clog.BlankLine,
+				clog.Tipf("use \"--help\" for more info"),
+			)
+		}
+		return nil
+	}
+}

--- a/internal/x/xcobra/cobra.go
+++ b/internal/x/xcobra/cobra.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"cdr.dev/coder-cli/pkg/clog"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +14,7 @@ func ExactArgs(n int) cobra.PositionalArgs {
 		if len(args) != n {
 			return clog.Error(
 				fmt.Sprintf("accepts %d arg(s), received %d", n, len(args)),
-				color.New(color.Bold).Sprintf("usage: ")+cmd.UseLine(),
+				clog.Bold("usage: ")+cmd.UseLine(),
 				clog.BlankLine,
 				clog.Tipf("use \"--help\" for more info"),
 			)


### PR DESCRIPTION
Closes #200 

```
╰─>$ coder login
error: accepts 1 arg(s), received 0
  | usage: coder login [Coder Enterprise URL eg. https://my.coder.domain/] [flags]
  | 
  | tip: use "--help" for more info

exit status 1
```