### PR TITLE
fix: Force bash for non-standard flags to exec

### DIFF
--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -82,15 +82,20 @@ coder sh front-end-dev cat ~/config.json`,
 
 func shell(cmd *cobra.Command, cmdArgs []string) error {
 	ctx := cmd.Context()
-	command := "sh"
-	args := []string{"-c"}
+	var command string
+	var args []string
 	if len(cmdArgs) > 1 {
+		command = "/bin/sh"
+		args = []string{"-c"}
 		args = append(args, strings.Join(cmdArgs[1:], " "))
 	} else {
 		// Bring user into shell if no command is specified.
 		shell := "$(getent passwd $(id -u) | cut -d: -f 7)"
-		name := "-$(basename " + shell + ")"
-		args = append(args, fmt.Sprintf("exec -a %q %q", name, shell))
+
+		// force bash for the '-l' flag to the exec built-in
+		command = "/bin/bash"
+		args = []string{"-c"}
+		args = append(args, fmt.Sprintf("exec -l %q", shell))
 	}
 
 	envName := cmdArgs[0]


### PR DESCRIPTION
This addresses a regression introduced by #224. POSIX `sh` does not define arguments to the `exec` built-in, resulting in an error when using `exec -a` to set the process name (`argv[0]`).

This change executes `/bin/bash` instead of `sh`, and also changes to use `exec -l`, which automatically handles the hyphen prefix required to trigger login shell behavior.

This also explicitly runs `/bin/sh`, aligning the behavior of `coder sh` and the frontend Terminal application.

Tested this using Arch Linux (enterprise-dev image) as well as the base Debian image from DockerHub.

```console
[coder@jawnsy-m coder-cli]$ go install ./cmd/coder
[coder@jawnsy-m coder-cli]$ which coder
/home/coder/go/bin/coder
[coder@jawnsy-m coder-cli]$ coder sh jawnsy-m
warning: version mismatch detected
  | Coder CLI version: unknown
  | Coder API version: 1.14.0+340-gd64a44cb3-20210123
  | 
  | tip: download the appropriate version here: https://github.com/cdr/coder-cli/releases
[coder@jawnsy-m ~]$ shopt login_shell
login_shell     on
[coder@jawnsy-m ~]$ exit
logout
[coder@jawnsy-m coder-cli]$ coder sh jawnsy-debian
warning: version mismatch detected
  | Coder CLI version: unknown
  | Coder API version: 1.14.0+340-gd64a44cb3-20210123
  | 
  | tip: download the appropriate version here: https://github.com/cdr/coder-cli/releases
root@jawnsy-debian:~# shopt login_shell
login_shell     on
root@jawnsy-debian:~# exit
logout
```