### PR TITLE
fix: Escape shell arguments

### DIFF
--- a/internal/cmd/shell_test.go
+++ b/internal/cmd/shell_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import "testing"
+
+func TestShellEscape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name    string
+		Input   string
+		Escaped string
+	}{
+		{
+			Name:    "single space",
+			Input:   "hello world",
+			Escaped: `hello\ world`,
+		},
+		{
+			Name:    "multiple spaces",
+			Input:   "test message hello  world",
+			Escaped: `test\ message\ hello\ \ world`,
+		},
+		{
+			Name:    "mixed quotes",
+			Input:   `"''"`,
+			Escaped: `\"\'\'\"`,
+		},
+		{
+			Name:    "mixed escaped quotes",
+			Input:   `"'\"\"'"`,
+			Escaped: `\"\'\\\"\\\"\'\"`,
+		},
+	}
+
+	for _, test := range tests {
+		if e, a := test.Escaped, shellEscape(test.Input); e != a {
+			t.Fatalf("test %q failed; expected: %q, got %q (input: %q)",
+				test.Name, test.Escaped, a, test.Input)
+		}
+	}
+}


### PR DESCRIPTION
The commands passed to "coder sh" are passed as a single argument to "sh -c", so we need to shell-escape the command we pass. This change escapes spaces, backslash, and quotes.

I'm not 100% sure if this is a good idea, since it is a breaking change in case people have already been escaping their commands.

Note: this will need to be rebased once #226 is merged

Tested as follows:

```console
[coder@jawnsy-m coder-cli]$ go install ./cmd/coder
[coder@jawnsy-m coder-cli]$ which coder
/home/coder/go/bin/coder
[coder@jawnsy-m coder-cli]$ coder sh jawnsy-m go run ~/test.go 1 2 "3 4" '"abc def" \\abc' 5 6 "7 8 9"
warning: version mismatch detected
  | Coder CLI version: unknown
  | Coder API version: 1.14.0+340-gd64a44cb3-20210123
  | 
  | tip: download the appropriate version here: https://github.com/cdr/coder-cli/releases
argv[0] = /tmp/go-build627553793/b001/exe/test
argv[1] = 1
argv[2] = 2
argv[3] = 3 4
argv[4] = "abc def" \\abc
argv[5] = 5
argv[6] = 6
argv[7] = 7 8 9
[coder@jawnsy-m coder-cli]$ go run ~/test.go 1 2 "3 4" '"abc def" \\abc' 5 6 "7 8 9"
argv[0] = /tmp/go-build909559834/b001/exe/test
argv[1] = 1
argv[2] = 2
argv[3] = 3 4
argv[4] = "abc def" \\abc
argv[5] = 5
argv[6] = 6
argv[7] = 7 8 9
```

For comparison, this is what `sh -c` and `exec` would look like:

```console
[coder@jawnsy-m coder-cli]$ sh -c "go run ~/test.go 1 2 \"3 4\" '\"abc def\" \\abc' 5 6 \"7 8 9\""
argv[0] = /tmp/go-build754337722/b001/exe/test
argv[1] = 1
argv[2] = 2
argv[3] = 3 4
argv[4] = "abc def" \abc
argv[5] = 5
argv[6] = 6
argv[7] = 7 8 9
[coder@jawnsy-m coder-cli]$ bash
[coder@jawnsy-m coder-cli]$ exec go run ~/test.go 1 2 "3 4" '"abc def" \\abc' 5 6 "7 8 9"
argv[0] = /tmp/go-build905411501/b001/exe/test
argv[1] = 1
argv[2] = 2
argv[3] = 3 4
argv[4] = "abc def" \\abc
argv[5] = 5
argv[6] = 6
argv[7] = 7 8 9
```

And this was the previous behavior:

```console
[coder@jawnsy-m coder-cli]$ which coder
/opt/coder/coder-cli/coder
[coder@jawnsy-m coder-cli]$ coder sh jawnsy-m go run ~/test.go 1 2 "3 4" '"abc def" \\abc' 5 6 "7 8 9"
warning: version mismatch detected
  | Coder CLI version: v1.15.0-8-gae35620
  | Coder API version: 1.14.0+340-gd64a44cb3-20210123
  | 
  | tip: download the appropriate version here: https://github.com/cdr/coder-cli/releases
argv[0] = /tmp/go-build394408240/b001/exe/test
argv[1] = 1
argv[2] = 2
argv[3] = 3
argv[4] = 4
argv[5] = abc def
argv[6] = \abc
argv[7] = 5
argv[8] = 6
argv[9] = 7
argv[10] = 8
argv[11] = 9
```