### PR TITLE
chore: Clean up CI scripts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,11 @@
 name: build
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:
@@ -10,29 +16,45 @@ jobs:
       - name: Build
         run: make -j build/linux build/windows
       - name: Upload
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v2
         with:
           name: coder-cli
           path: ./ci/bin/coder-cli-*
-  build_darwin:
+
+  build_darwin_pull:
     runs-on: macos-latest
+    if: github.ref != 'refs/heads/master'
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+      - name: Build
+        run: unset CI && make build/macos
+
+  build_darwin_master:
+    runs-on: macos-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Install Gon
         run: |
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
+
       - name: Import Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v1
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
-      - name: Build
+
+      - name: Build master
         run: make build/macos
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+
       - name: Upload
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Show git tags
+        run: git describe --tags
       - name: Build
         run: unset CI && make build/macos
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,8 +13,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
       - name: Build
         run: make -j build/linux build/windows
+
       - name: Upload
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v2
@@ -28,10 +32,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Show git tags
-        run: git tag
-      - name: Show git tags
-        run: git describe --tags
+        with:
+          fetch-depth: 0
+
       - name: Build
         run: unset CI && make build/macos
 
@@ -41,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install Gon
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
         with:
+          # Fetch depth 0 is needed for 'git describe --tag'
           fetch-depth: 0
 
       - name: Build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Show git tags
+        run: git tag
+      - name: Show git tags
         run: git describe --tags
       - name: Build
         run: unset CI && make build/macos

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,6 +1,8 @@
 name: integration
 on:
   push:
+    branches:
+    - master
   schedule:
     - cron:  '*/180 * * * *'
 
@@ -12,8 +14,8 @@ jobs:
       CODER_EMAIL: ${{ secrets.CODER_EMAIL }}
       CODER_PASSWORD: ${{ secrets.CODER_PASSWORD }}
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -21,6 +23,6 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14'
+          go-version: '^1.15'
       - name: integration tests
         run: ./ci/scripts/integration.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,18 @@
 name: test
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -25,12 +31,12 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.36
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -43,8 +49,8 @@ jobs:
   gendocs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
* Build with Go provided by GitHub instead of building inside a Dockerfile, which should speed up the build
* Condense build steps to avoid repeatedly downloading cached Go packages, which should speed up the build
* Run goimports using golangci-lint, rather than running gofmt and goimports manually in make fmt
* Skip signing/notarizing Darwin binary in build, since this takes a long time and is done in release
* Only build/test for pull requests against master
* Remove unnecessary steps in ci/image/Dockerfile
  * goimports is managed by golangci-lint
  * grep is already installed in the base image