### PR TITLE
feat: move to new config schema and location

### DIFF
--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"cdr.dev/coder-cli/internal/cmd"
+	"cdr.dev/coder-cli/internal/config"
 	"cdr.dev/coder-cli/internal/version"
 	"cdr.dev/coder-cli/internal/x/xterminal"
 	"cdr.dev/coder-cli/pkg/clog"
@@ -23,6 +24,11 @@ func main() {
 		go func() {
 			log.Println(http.ListenAndServe("localhost:6060", nil))
 		}()
+	}
+
+	err := config.MigrateFromOld()
+	if err != nil {
+		panic(err)
 	}
 
 	stdoutState, err := xterminal.MakeOutputRaw(os.Stdout.Fd())

--- a/go.mod
+++ b/go.mod
@@ -23,5 +23,6 @@ require (
 	golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	nhooyr.io/websocket v1.8.6
 )

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -31,15 +31,13 @@ func newClient(ctx context.Context) (*coder.Client, error) {
 	)
 
 	if sessionToken == "" || rawURL == "" {
-		sessionToken, err = config.Session.Read()
+		var creds config.Credentials
+		err := config.CredentialsFile.UnmarshalYAML(&creds)
 		if err != nil {
 			return nil, errNeedLogin
 		}
-
-		rawURL, err = config.URL.Read()
-		if err != nil {
-			return nil, errNeedLogin
-		}
+		sessionToken = creds.SessionToken
+		rawURL = creds.DashboardURL
 	}
 
 	u, err := url.Parse(rawURL)

--- a/internal/cmd/configssh.go
+++ b/internal/cmd/configssh.go
@@ -210,11 +210,12 @@ func makeSSHConfig(host, userName, envName, privateKeyFilepath string) string {
 
 //nolint:deadcode,unused
 func configuredHostname() (string, error) {
-	u, err := config.URL.Read()
+	var creds config.Credentials
+	err := config.CredentialsFile.UnmarshalYAML(&creds)
 	if err != nil {
 		return "", err
 	}
-	url, err := url.Parse(u)
+	url, err := url.Parse(creds.DashboardURL)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -19,7 +19,7 @@ func logoutCmd() *cobra.Command {
 }
 
 func logout(_ *cobra.Command, _ []string) error {
-	err := config.Session.Delete()
+	err := config.CredentialsFile.Delete()
 	if err != nil {
 		if os.IsNotExist(err) {
 			clog.LogInfo("no active session")

--- a/internal/config/deprecated.go
+++ b/internal/config/deprecated.go
@@ -1,0 +1,9 @@
+package config
+
+// Coder CLI configuration files.
+var (
+	// Deprecated.
+	Session File = "session"
+	// Depcreated.
+	URL File = "url"
+)

--- a/internal/config/dir.go
+++ b/internal/config/dir.go
@@ -17,6 +17,8 @@ func dir() (string, error) {
 	return filepath.Join(homedir, ".coder"), nil
 }
 
+// MigrateFromOld ensures that users of the CLI are properly authenticated with the new ~/.coder/credentials.yaml
+// authentication schema.
 func MigrateFromOld() error {
 	olddir := configdir.LocalConfig("coder")
 	_, err := os.Stat(olddir)

--- a/internal/config/dir.go
+++ b/internal/config/dir.go
@@ -6,18 +6,55 @@ import (
 	"path/filepath"
 
 	"github.com/kirsle/configdir"
+	"golang.org/x/xerrors"
 )
 
-func dir() string {
-	return configdir.LocalConfig("coder")
+func dir() (string, error) {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return "", xerrors.Errorf("get home dir: %w", err)
+	}
+	return filepath.Join(homedir, ".coder"), nil
+}
+
+func MigrateFromOld() error {
+	olddir := configdir.LocalConfig("coder")
+	_, err := os.Stat(olddir)
+	if err != nil {
+		// if we can't stat the old config dir, assume it does not exist
+		return nil
+	}
+	session, err := ioutil.ReadFile(filepath.Join(olddir, "session"))
+	if err != nil {
+		return xerrors.Errorf("read session: %w", err)
+	}
+	url, err := ioutil.ReadFile(filepath.Join(olddir, "url"))
+	if err != nil {
+		return xerrors.Errorf("read session: %w", err)
+	}
+	creds := Credentials{
+		SessionToken: string(session),
+		DashboardURL: string(url),
+	}
+	if err := CredentialsFile.WriteYAML(creds); err != nil {
+		return xerrors.Errorf("write credentials file: %w", err)
+	}
+	if err := os.RemoveAll(olddir); err != nil {
+		return xerrors.Errorf("remove old config dir: %w", err)
+	}
+	return nil
 }
 
 // open opens a file in the configuration directory,
 // creating all intermediate directories.
 func open(path string, flag int, mode os.FileMode) (*os.File, error) {
-	path = filepath.Join(dir(), path)
+	configDir, err := dir()
+	if err != nil {
+		return nil, err
+	}
+	path = filepath.Join(configDir, path)
 
-	err := os.MkdirAll(filepath.Dir(path), 0750)
+	err = os.MkdirAll(filepath.Dir(path), 0750)
 	if err != nil {
 		return nil, err
 	}
@@ -45,5 +82,9 @@ func read(path string) ([]byte, error) {
 }
 
 func rm(path string) error {
-	return os.Remove(filepath.Join(dir(), path))
+	configDir, err := dir()
+	if err != nil {
+		return err
+	}
+	return os.Remove(filepath.Join(configDir, path))
 }

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -45,28 +45,34 @@ func (f File) WriteYAML(in interface{}) error {
 	return f.Write(string(encoded))
 }
 
+// The following files configure and authenticate the coder-cli in ~/.coder/.
 const (
 	CredentialsFile File = "credentials.yaml"
 	ConfigFile      File = "config.yaml"
 )
 
+// Credentials defines the schema for the ~/.coder/credentials.yaml file.
 type Credentials struct {
 	DashboardURL string `yaml:"url"`
 	SessionToken string `yaml:"session"`
 }
 
+// CoderConfig defines the schema for the ~/.coder/config.yaml file.
 type CoderConfig struct {
 	Version  string        `yaml:"version"`
 	Defaults CoderDefaults `yaml:"defaults"`
 }
 
+// CoderDefaults defines the schema for the default user configuration located in the global config file.
 type CoderDefaults struct {
 	Environment string `yaml:"environment"`
 	Editor      Editor `yaml:"editor"`
 }
 
+// Editor defines an editor which coder-cli can open.
 type Editor string
 
+// The following editors may be specified as targets of `coder open`.
 const (
 	EditorVSCode        Editor = "vscode"
 	EditorBrowserVSCode Editor = "browser-vscode"


### PR DESCRIPTION
No rush to merge this, but it will open up some nice opportunities when it lands.

This PR changes the way we store user config and credentials to support the growing scope of `coder-cli`. 

## Current State
```
~/.config/coder/session
~/.config/coder/url
```

## New State
`~/.coder/credentials.yaml`:
```yaml
url: https://master.cdr.dev
session: 1234321
```

## Future
`~/.coder/config.yaml`
```yaml
default:
  editor: vscode
  environment: dev1
```
