### PR TITLE
feat: split parsing config from creating env

### DIFF
--- a/coder-sdk/ws.go
+++ b/coder-sdk/ws.go
@@ -3,30 +3,9 @@ package coder
 import (
 	"context"
 	"net/http"
-	"net/url"
 
 	"nhooyr.io/websocket"
 )
-
-type requestOptions struct {
-	BaseURLOverride *url.URL
-	Query           url.Values
-}
-
-type requestOption func(*requestOptions)
-
-// withQueryParams sets the provided query parameters on the request.
-func withQueryParams(q url.Values) func(o *requestOptions) {
-	return func(o *requestOptions) {
-		o.Query = q
-	}
-}
-
-func withBaseURL(base *url.URL) func(o *requestOptions) {
-	return func(o *requestOptions) {
-		o.BaseURLOverride = base
-	}
-}
 
 // dialWebsocket establish the websocket connection while setting the authentication header.
 func (c Client) dialWebsocket(ctx context.Context, path string, options ...requestOption) (*websocket.Conn, error) {


### PR DESCRIPTION
- Add an endpoint to parse a WAC template.
- Add support for specifying a local file.
- Decoupled creating an environment from parsing a template
  (in the API).