### PR TITLE
feat(cli): AutoStart education notice [ch7441]

### DIFF
--- a/coder-sdk/env.go
+++ b/coder-sdk/env.go
@@ -74,16 +74,17 @@ const (
 
 // CreateEnvironmentRequest is used to configure a new environment.
 type CreateEnvironmentRequest struct {
-	Name           string   `json:"name"`
-	ImageID        string   `json:"image_id"`
-	OrgID          string   `json:"org_id"`
-	ImageTag       string   `json:"image_tag"`
-	CPUCores       float32  `json:"cpu_cores"`
-	MemoryGB       float32  `json:"memory_gb"`
-	DiskGB         int      `json:"disk_gb"`
-	GPUs           int      `json:"gpus"`
-	Services       []string `json:"services"`
-	UseContainerVM bool     `json:"use_container_vm"`
+	Name            string   `json:"name"`
+	ImageID         string   `json:"image_id"`
+	OrgID           string   `json:"org_id"`
+	ImageTag        string   `json:"image_tag"`
+	CPUCores        float32  `json:"cpu_cores"`
+	MemoryGB        float32  `json:"memory_gb"`
+	DiskGB          int      `json:"disk_gb"`
+	GPUs            int      `json:"gpus"`
+	Services        []string `json:"services"`
+	UseContainerVM  bool     `json:"use_container_vm"`
+	EnableAutoStart bool     `json:"autostart_enabled"`
 }
 
 // CreateEnvironment sends a request to create an environment.

--- a/docs/coder_envs_create.md
+++ b/docs/coder_envs_create.md
@@ -24,6 +24,7 @@ coder envs create my-new-powerful-env --cpu 12 --disk 100 --memory 16 --image ub
       --container-based-vm   deploy the environment as a Container-based VM
   -c, --cpu float32          number of cpu cores the environment should be provisioned with.
   -d, --disk int             GB of disk storage an environment should be provisioned with.
+      --enable-autostart     automatically start this environment at your preferred time.
       --follow               follow buildlog after initiating rebuild
   -g, --gpus int             number GPUs an environment should be provisioned with.
   -h, --help                 help for create

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -152,16 +152,16 @@ coder envs --user charlie@coder.com ls -o json \
 
 func createEnvCmd() *cobra.Command {
 	var (
-		org    string
-		cpu    float32
-		memory float32
-		disk   int
-		gpus   int
-		img    string
-		tag    string
-		follow bool
-		useCVM bool
-		useAS  bool
+		org             string
+		cpu             float32
+		memory          float32
+		disk            int
+		gpus            int
+		img             string
+		tag             string
+		follow          bool
+		useCVM          bool
+		enableAutostart bool
 	)
 
 	cmd := &cobra.Command{
@@ -214,7 +214,7 @@ coder envs create my-new-powerful-env --cpu 12 --disk 100 --memory 16 --image ub
 				DiskGB:          disk,
 				GPUs:            gpus,
 				UseContainerVM:  useCVM,
-				EnableAutoStart: useAS,
+				EnableAutoStart: enableAutostart,
 			}
 
 			// if any of these defaulted to their zero value we provision
@@ -258,7 +258,7 @@ coder envs create my-new-powerful-env --cpu 12 --disk 100 --memory 16 --image ub
 	cmd.Flags().StringVarP(&img, "image", "i", "", "name of the image to base the environment off of.")
 	cmd.Flags().BoolVar(&follow, "follow", false, "follow buildlog after initiating rebuild")
 	cmd.Flags().BoolVar(&useCVM, "container-based-vm", false, "deploy the environment as a Container-based VM")
-	cmd.Flags().BoolVar(&useAS, "enable-autostart", false, "automatically start this environment at your preferred time.")
+	cmd.Flags().BoolVar(&enableAutostart, "enable-autostart", false, "automatically start this environment at your preferred time.")
 	_ = cmd.MarkFlagRequired("image")
 	return cmd
 }

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -622,7 +622,7 @@ func buildUpdateReq(ctx context.Context, client *coder.Client, conf updateConf) 
 	return &updateReq, nil
 }
 
-// TODO (Grey): Remove education in a future non-patch release
+// TODO (Grey): Remove education in a future non-patch release.
 func autoStartInfo() {
 	var preferencesURI string
 

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -622,6 +622,7 @@ func buildUpdateReq(ctx context.Context, client *coder.Client, conf updateConf) 
 	return &updateReq, nil
 }
 
+// TODO (Grey): Remove education in a future non-patch release
 func autoStartInfo() {
 	var preferencesURI string
 

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -29,6 +29,9 @@ func rebuildEnvCommand() *cobra.Command {
 		Args:  xcobra.ExactArgs(1),
 		Example: `coder envs rebuild front-end-env --follow
 coder envs rebuild backend-env --force`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			autoStartInfo()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := newClient(ctx)


### PR DESCRIPTION
I tried my best to get some cool info/ed information around AutoStart into the CLI :zap:

## Demo

### Env Pre-Run Cmds

I added this to:

- envs create
- envs rebuild

### Env Create

```
$ go run ./cmd/coder/main.go envs create created-from-cli --image ubuntu --enable-autostart --org Coder
info: ⚡NEW: Automate daily environment startup
  | Visit https://master.cdr.dev/preferences?tab=autostart to configure your preferred time
warning: version mismatch detected
  | Coder CLI version: unknown
  | Coder API version: 1.14.0+743-g7c24d16bb-20210216
  | 
  | tip: download the appropriate version here: https://github.com/cdr/coder-cli/releases
success: creating environment...
  | 
  | tip: run "coder envs watch-build created-from-cli" to trail the build logs
```

## Next Steps

Should we accept this effort, we should spawn a ticket to remove the education notice from the next non-patch release