### PR TITLE
Set IdentitiesOnly option when configuring ssh

### DIFF
--- a/internal/cmd/configssh.go
+++ b/internal/cmd/configssh.go
@@ -203,6 +203,7 @@ func makeSSHConfig(host, userName, envName, privateKeyFilepath string) string {
    User %s-%s
    StrictHostKeyChecking no
    ConnectTimeout=0
+   IdentitiesOnly yes
    IdentityFile="%s"
    ServerAliveInterval 60
    ServerAliveCountMax 3


### PR DESCRIPTION
This setting will prevent ssh from using identities found in ssh-agent. We're
already specifying the identity file, so there's no need to rely on ssh-agent
for this.

This will prevent 'too many authentication failures' errors when connecting to
an environment while having a lot of identities loaded in the agent.