### PR TITLE
feat: unconditionally show login URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/klauspost/compress v1.10.8 // indirect
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
-	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/rjeczalik/notify v0.9.2
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,6 @@ github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYX
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
@@ -106,12 +105,7 @@ func login(cmd *cobra.Command, envURL *url.URL, urlCfg, sessionCfg config.File) 
 	authURL.Path = envURL.Path + "/internal-auth"
 	authURL.RawQuery = "local_service=http://" + listener.Addr().String()
 
-	// Try to open the browser on the local computer.
-	if err := browser.OpenURL(authURL.String()); err != nil {
-		// Discard the error as it is an expected one in non-X environments like over ssh.
-		// Tell the user to visit the URL instead.
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Visit the following URL in your browser:\n\n\t%s\n\n", &authURL) // Can't fail.
-	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Visit the following URL in your browser:\n\n\t%s\n\n", &authURL)
 
 	// Create our channel, it is going to be the central synchronization of the command.
 	tokenChan := make(chan string)


### PR DESCRIPTION
Do not attempt to open the user's browser, because their default
browser may not be their preferred one. The user may be logged in
to Coder using multiple accounts on different browsers, or they
may not use their default browser for Coder.

Tools like gcloud unconditionally show a login URL, so that the
user can decide where to open it.