### PR TITLE
chore: add code coverage reporting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,10 +3,10 @@ on: [push]
 
 jobs:
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -18,19 +18,19 @@ jobs:
           args: make -j fmt 
       - run: ./ci/scripts/files_changed.sh
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.36
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -38,13 +38,15 @@ jobs:
             ${{ runner.os }}-go-
       - name: test
         uses: ./ci/image
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: make -j test/go
+          args: make -j test/coverage
   gendocs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,12 @@ gendocs:
 
 test/go:
 	go test $$(go list ./... | grep -v pkg/tcli | grep -v ci/integration | grep -v coder-sdk)
+
+test/coverage:
+	go test \
+		-race \
+		-covermode atomic \
+		-coverprofile coverage \
+		$$(go list ./... | grep -v pkg/tcli | grep -v ci/integration | grep -v coder-sdk)
+
+	goveralls -coverprofile=coverage -service=github


### PR DESCRIPTION
* Update actions to latest versions
* Update golangci-lint to latest version, 1.36
* Pin Ubuntu to the latest, version 20.04
* Add coverage profiling test and send results to Coveralls