### PR TITLE
feat: add password authentication to coder-sdk

### DIFF
--- a/coder-sdk/client.go
+++ b/coder-sdk/client.go
@@ -29,26 +29,26 @@ type ClientOptions struct {
 	// Token is the API Token used to authenticate (optional).
 	//
 	// If Token is provided, the DefaultClient will use it to
-	// authenticate. If it is not provided, it will require another
-	// type of credential, such as a Email/Password pair.
+	// authenticate. If it is not provided, the client require
+	// another type of credential, such as an Email/Password pair.
 	Token string
 
-	// Email will be used to authenticate.
+	// Email used to authenticate with Coder.
 	//
-	// DefaultClient requires exactly one type of credential
-	// (Token, or Email/Password pair).
-	//
-	// NewClient will exchange the Email and Password for a Token
-	// and will not retain them in-memory after NewClient returns.
+	// If you supply an Email and Password pair, NewClient will
+	// exchange these credentials for a Token during initialization.
+	// This is only applicable for the built-in authentication
+	// provider. The client will not retain these credentials in
+	// memory after NewClient returns.
 	Email string
 
-	// Password will be used to authenticate.
+	// Password used to authenticate with Coder.
 	//
-	// DefaultClient requires exactly one type of credential
-	// (Token, or Email/Password pair).
-	//
-	// NewClient will exchange the Email and Password for a Token
-	// and will not retain them in-memory after NewClient returns.
+	// If you supply an Email and Password pair, NewClient will
+	// exchange these credentials for a Token during initialization.
+	// This is only applicable for the built-in authentication
+	// provider. The client will not retain these credentials in
+	// memory after NewClient returns.
 	Password string
 }
 

--- a/coder-sdk/client.go
+++ b/coder-sdk/client.go
@@ -1,9 +1,13 @@
 package coder
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
+	"time"
+
+	"golang.org/x/xerrors"
 )
 
 // ensure that DefaultClient implements Client.
@@ -14,15 +18,38 @@ const Me = "me"
 
 // ClientOptions contains options for the Coder SDK Client.
 type ClientOptions struct {
-	// BaseURL is the root URL of the Coder installation.
+	// BaseURL is the root URL of the Coder installation (required).
 	BaseURL *url.URL
 
 	// Client is the http.Client to use for requests (optional).
+	//
 	// If omitted, the http.DefaultClient will be used.
 	HTTPClient *http.Client
 
-	// Token is the API Token used to authenticate
+	// Token is the API Token used to authenticate (optional).
+	//
+	// If Token is provided, the DefaultClient will use it to
+	// authenticate. If it is not provided, it will require another
+	// type of credential, such as a Email/Password pair.
 	Token string
+
+	// Email will be used to authenticate.
+	//
+	// DefaultClient requires exactly one type of credential
+	// (Token, or Email/Password pair).
+	//
+	// NewClient will exchange the Email and Password for a Token
+	// and will not retain them in-memory after NewClient returns.
+	Email string
+
+	// Password will be used to authenticate.
+	//
+	// DefaultClient requires exactly one type of credential
+	// (Token, or Email/Password pair).
+	//
+	// NewClient will exchange the Email and Password for a Token
+	// and will not retain them in-memory after NewClient returns.
+	Password string
 }
 
 // NewClient creates a new default Coder SDK client.
@@ -36,14 +63,38 @@ func NewClient(opts ClientOptions) (*DefaultClient, error) {
 		return nil, errors.New("the BaseURL parameter is required")
 	}
 
-	if opts.Token == "" {
-		return nil, errors.New("an API token is required")
+	token := opts.Token
+	if token == "" {
+		if opts.Email == "" || opts.Password == "" {
+			return nil, errors.New("either an API Token or email/password pair are required")
+		}
+
+		// Exchange the username/password for a token.
+		// We apply a default timeout of 5 seconds here.
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		resp, err := LoginWithPassword(ctx, httpClient, opts.BaseURL, &LoginRequest{
+			Email:    opts.Email,
+			Password: opts.Password,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to login with email/password: %w", err)
+		}
+
+		token = resp.SessionToken
+		if token == "" {
+			return nil, errors.New("server returned an empty session token")
+		}
 	}
+
+	// TODO: add basic validation to make sure the token looks OK.
 
 	client := &DefaultClient{
 		baseURL:    opts.BaseURL,
 		httpClient: httpClient,
-		token:      opts.Token,
+		token:      token,
 	}
 
 	return client, nil

--- a/coder-sdk/client.go
+++ b/coder-sdk/client.go
@@ -29,7 +29,7 @@ type ClientOptions struct {
 	// Token is the API Token used to authenticate (optional).
 	//
 	// If Token is provided, the DefaultClient will use it to
-	// authenticate. If it is not provided, the client require
+	// authenticate. If it is not provided, the client requires
 	// another type of credential, such as an Email/Password pair.
 	Token string
 

--- a/coder-sdk/login.go
+++ b/coder-sdk/login.go
@@ -12,11 +12,21 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// LoginRequest is a request to authenticate using email
+// and password credentials.
+//
+// This is provided for use in tests, and we recommend users authenticate
+// using an API Token.
 type LoginRequest struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
 }
 
+// LoginResponse contains successful response data for an authentication
+// request, including an API Token to be used for subsequent requests.
+//
+// This is provided for use in tests, and we recommend users authenticate
+// using an API Token.
 type LoginResponse struct {
 	SessionToken string `json:"session_token"`
 }

--- a/coder-sdk/login.go
+++ b/coder-sdk/login.go
@@ -1,0 +1,59 @@
+package coder
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+type LoginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type LoginResponse struct {
+	SessionToken string `json:"session_token"`
+}
+
+// LoginWithPassword exchanges the email/password pair for
+// a Session Token.
+//
+// If client is nil, the http.DefaultClient will be used.
+func LoginWithPassword(ctx context.Context, client *http.Client, baseURL *url.URL, req *LoginRequest) (resp *LoginResponse, err error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	url := *baseURL
+	url.Path = fmt.Sprint(strings.TrimSuffix(url.Path, "/"), "/auth/basic/login")
+
+	buf := &bytes.Buffer{}
+	err = json.NewEncoder(buf).Encode(req)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to marshal JSON: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), buf)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create request: %w", err)
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, xerrors.Errorf("error processing login request: %w", err)
+	}
+	defer response.Body.Close()
+
+	err = json.NewDecoder(response.Body).Decode(&resp)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to decode response: %w", err)
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
This enables authenticating to Coder using the coder-sdk using an
email/password combination (basic authentication). As it is intended
for test purposes only, it is not exposed via coder-cli.