### PR TITLE
chore: use dependabot to manage dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "11:00"
+  open-pull-requests-limit: 10
+  assignees:
+    - "dependabot"
+
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  assignees:
+    - "dependabot"


### PR DESCRIPTION
Use dependabot to manage the dependencies defined in go.mod and
GitHub Actions workflows, so that we can proactively update versions.

Outdated versions of third-party dependencies frequently have known
security vulnerabilities with CVEs.