### PR TITLE
chore: remove dependency on stretchr/testify

### DIFF
--- a/ci/integration/envs_test.go
+++ b/ci/integration/envs_test.go
@@ -14,7 +14,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"cdr.dev/slog/sloggers/slogtest/assert"
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 
 	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/coder-cli/pkg/tcli"
@@ -30,7 +29,7 @@ func cleanupClient(ctx context.Context, t *testing.T) coder.Client {
 		BaseURL: u,
 		Token:   creds.token,
 	})
-	require.NoError(t, err, "failed to create coder.Client")
+	assert.Success(t, "failed to create coder.Client", err)
 	return client
 }
 

--- a/coder-sdk/activity_test.go
+++ b/coder-sdk/activity_test.go
@@ -8,8 +8,9 @@ import (
 	"net/url"
 	"testing"
 
-	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/slog/sloggers/slogtest/assert"
+
+	"cdr.dev/coder-cli/coder-sdk"
 )
 
 func TestPushActivity(t *testing.T) {

--- a/coder-sdk/activity_test.go
+++ b/coder-sdk/activity_test.go
@@ -8,9 +8,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/slog/sloggers/slogtest/assert"
 )
 
 func TestPushActivity(t *testing.T) {
@@ -19,8 +18,8 @@ func TestPushActivity(t *testing.T) {
 	const source = "test"
 	const envID = "602d377a-e6b8d763cae7561885c5f1b2"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method, "PushActivity is a POST")
-		require.Equal(t, "/api/private/metrics/usage/push", r.URL.Path)
+		assert.Equal(t, "PushActivity is a POST", http.MethodPost, r.Method)
+		assert.Equal(t, "URL matches", "/api/private/metrics/usage/push", r.URL.Path)
 
 		expected := map[string]interface{}{
 			"source":         source,
@@ -28,8 +27,8 @@ func TestPushActivity(t *testing.T) {
 		}
 		var request map[string]interface{}
 		err := json.NewDecoder(r.Body).Decode(&request)
-		require.NoError(t, err, "error decoding JSON")
-		require.EqualValues(t, expected, request, "unexpected request data")
+		assert.Success(t, "error decoding JSON", err)
+		assert.Equal(t, "unexpected request data", expected, request)
 
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -38,14 +37,14 @@ func TestPushActivity(t *testing.T) {
 	})
 
 	u, err := url.Parse(server.URL)
-	require.NoError(t, err, "failed to parse test server URL")
+	assert.Success(t, "failed to parse test server URL", err)
 
 	client, err := coder.NewClient(coder.ClientOptions{
 		BaseURL: u,
 		Token:   "SwdcSoq5Jc-0C1r8wfwm7h6h9i0RDk7JT",
 	})
-	require.NoError(t, err, "failed to create coder.Client")
+	assert.Success(t, "failed to create coder.Client", err)
 
 	err = client.PushActivity(context.Background(), source, envID)
-	require.NoError(t, err)
+	assert.Success(t, "expected successful response from PushActivity", err)
 }

--- a/coder-sdk/client_test.go
+++ b/coder-sdk/client_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/slog/sloggers/slogtest/assert"
+
+	"cdr.dev/coder-cli/coder-sdk"
 )
 
 func TestAuthentication(t *testing.T) {

--- a/coder-sdk/users_test.go
+++ b/coder-sdk/users_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/slog/sloggers/slogtest/assert"
+
+	"cdr.dev/coder-cli/coder-sdk"
 )
 
 func TestUsers(t *testing.T) {

--- a/coder-sdk/users_test.go
+++ b/coder-sdk/users_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/slog/sloggers/slogtest/assert"
 )
 
 func TestUsers(t *testing.T) {
@@ -21,8 +20,8 @@ func TestUsers(t *testing.T) {
 	const name = "Charlie Root"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method, "Users is a GET")
-		require.Equal(t, "/api/v0/users", r.URL.Path)
+		assert.Equal(t, "Users is a GET", http.MethodGet, r.Method)
+		assert.Equal(t, "Path matches", "/api/v0/users", r.URL.Path)
 
 		users := []map[string]interface{}{
 			{
@@ -41,26 +40,26 @@ func TestUsers(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		err := json.NewEncoder(w).Encode(users)
-		require.NoError(t, err, "error encoding JSON")
+		assert.Success(t, "error encoding JSON", err)
 	}))
 	t.Cleanup(func() {
 		server.Close()
 	})
 
 	u, err := url.Parse(server.URL)
-	require.NoError(t, err, "failed to parse test server URL")
+	assert.Success(t, "failed to parse test server URL", err)
 
 	client, err := coder.NewClient(coder.ClientOptions{
 		BaseURL: u,
 		Token:   "JcmErkJjju-KSrztst0IJX7xGJhKQPtfv",
 	})
-	require.NoError(t, err, "failed to create coder.Client")
+	assert.Success(t, "failed to create coder.Client", err)
 
 	users, err := client.Users(context.Background())
-	require.NoError(t, err, "error getting Users")
-	require.Len(t, users, 1, "users should return a single user")
-	require.Equal(t, name, users[0].Name)
-	require.Equal(t, username, users[0].Username)
+	assert.Success(t, "error getting Users", err)
+	assert.True(t, "users should return a single user", len(users) == 1)
+	assert.Equal(t, "expected user's name to match", name, users[0].Name)
+	assert.Equal(t, "expected user's username to match", username, users[0].Username)
 }
 
 func TestUserUpdatePassword(t *testing.T) {
@@ -70,8 +69,8 @@ func TestUserUpdatePassword(t *testing.T) {
 	const newPassword = "wmf39jw2f7pk"
 
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPatch, r.Method, "Users is a PATCH")
-		require.Equal(t, "/api/v0/users/me", r.URL.Path)
+		assert.Equal(t, "Users is a PATCH", http.MethodPatch, r.Method)
+		assert.Equal(t, "Path matches", "/api/v0/users/me", r.URL.Path)
 
 		expected := map[string]interface{}{
 			"old_password": oldPassword,
@@ -79,8 +78,8 @@ func TestUserUpdatePassword(t *testing.T) {
 		}
 		var request map[string]interface{}
 		err := json.NewDecoder(r.Body).Decode(&request)
-		require.NoError(t, err, "error decoding JSON")
-		require.EqualValues(t, expected, request, "unexpected request data")
+		assert.Success(t, "error decoding JSON", err)
+		assert.Equal(t, "unexpected request data", expected, request)
 
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -89,14 +88,14 @@ func TestUserUpdatePassword(t *testing.T) {
 	})
 
 	u, err := url.Parse(server.URL)
-	require.NoError(t, err, "failed to parse test server URL")
+	assert.Success(t, "failed to parse test server URL", err)
 
 	client, err := coder.NewClient(coder.ClientOptions{
 		BaseURL:    u,
 		HTTPClient: server.Client(),
 		Token:      "JcmErkJjju-KSrztst0IJX7xGJhKQPtfv",
 	})
-	require.NoError(t, err, "failed to create coder.Client")
+	assert.Success(t, "failed to create coder.Client", err)
 
 	err = client.UpdateUser(context.Background(), "me", coder.UpdateUserReq{
 		UserPasswordSettings: &coder.UserPasswordSettings{
@@ -105,5 +104,5 @@ func TestUserUpdatePassword(t *testing.T) {
 			Temporary:   false,
 		},
 	})
-	require.NoError(t, err, "error when updating password")
+	assert.Success(t, "error when updating password", err)
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/rjeczalik/notify v0.9.2
 	github.com/spf13/cobra v1.1.1
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/internal/loginsrv/input_test.go
+++ b/internal/loginsrv/input_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"cdr.dev/coder-cli/internal/loginsrv"
+	"cdr.dev/slog/sloggers/slogtest/assert"
 )
 
 // 100ms is plenty of time as we are dealing with simple in-memory pipe.
@@ -62,14 +61,14 @@ func TestReadLine(t *testing.T) {
 			case err := <-errChan:
 				t.Fatalf("ReadLine returned before we got the token (%v).", err)
 			case actualToken := <-tokenChan:
-				require.Equal(t, testToken, actualToken, "Unexpected token received from readline.")
+				assert.Equal(t, "Unexpected token received from readline.", testToken, actualToken)
 			}
 
 			select {
 			case <-ctx.Done():
 				t.Fatal("Timeout waiting for readline to finish.")
 			case err := <-errChan:
-				require.NoError(t, err, "Error reading the line.")
+				assert.Success(t, "Error reading the line.", err)
 			}
 		})
 	}
@@ -119,7 +118,7 @@ func TestReadLineMissingToken(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("Timeout waiting for readline to finish.")
 	case err := <-errChan:
-		require.NoError(t, err, "Error reading the line.")
+		assert.Success(t, "Error reading the line.", err)
 	case token, ok := <-tokenChan:
 		t.Fatalf("Token channel unexpectedly unblocked. Data: %q, state: %t.", token, ok)
 	}

--- a/internal/loginsrv/input_test.go
+++ b/internal/loginsrv/input_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"cdr.dev/coder-cli/internal/loginsrv"
 	"cdr.dev/slog/sloggers/slogtest/assert"
+
+	"cdr.dev/coder-cli/internal/loginsrv"
 )
 
 // 100ms is plenty of time as we are dealing with simple in-memory pipe.

--- a/internal/loginsrv/server_test.go
+++ b/internal/loginsrv/server_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"cdr.dev/coder-cli/internal/loginsrv"
 	"cdr.dev/slog/sloggers/slogtest/assert"
+
+	"cdr.dev/coder-cli/internal/loginsrv"
 )
 
 // 500ms should be plenty enough, even on slow machine to perform the request/response cycle.


### PR DESCRIPTION
This switches tests from stretchr/testify to our preferred slogtest
assertion library.