### PR TITLE
chore: ignore minor versions for official actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,15 @@ updates:
     interval: "daily"
     time: "11:00"
   open-pull-requests-limit: 10
-  assignees:
-    - "dependabot"
+  ignore:
+    # GitHub always delivers the latest versions for each major
+    # release tag, so ignore minor version tags
+    - dependency-name: "actions/cache"
+      versions:
+        - 2.x
+    - dependency-name: "actions/checkout"
+      versions:
+        - 2.x
 
 - package-ecosystem: gomod
   directory: "/"
@@ -15,5 +22,3 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
-  assignees:
-    - "dependabot"


### PR DESCRIPTION
* Ignore minor versions for actions/cache and actions/checkout,
  since GitHub always replaces the v2 tag with the latest minor
  release
* Remove assignee setting, since it doesn't seem to work