### PR TITLE
Handle wac template parse errors

### DIFF
--- a/coder-sdk/error.go
+++ b/coder-sdk/error.go
@@ -17,7 +17,7 @@ var ErrPermissions = xerrors.New("insufficient permissions")
 // ErrAuthentication describes the error case in which the requester has invalid authentication.
 var ErrAuthentication = xerrors.New("invalid authentication")
 
-// APIError is the expected payload format for our errors.
+// APIError is the expected payload format for API errors.
 type APIError struct {
 	Err APIErrorMsg `json:"error"`
 }

--- a/coder-sdk/error.go
+++ b/coder-sdk/error.go
@@ -17,13 +17,13 @@ var ErrPermissions = xerrors.New("insufficient permissions")
 // ErrAuthentication describes the error case in which the requester has invalid authentication.
 var ErrAuthentication = xerrors.New("invalid authentication")
 
-// apiError is the expected payload format for our errors.
-type apiError struct {
-	Err apiErrorMsg `json:"error"`
+// APIError is the expected payload format for our errors.
+type APIError struct {
+	Err APIErrorMsg `json:"error"`
 }
 
-// apiErrorMsg contains the rich error information returned by API errors.
-type apiErrorMsg struct {
+// APIErrorMsg contains the rich error information returned by API errors.
+type APIErrorMsg struct {
 	Msg     string          `json:"msg"`
 	Code    string          `json:"code"`
 	Details json.RawMessage `json:"details"`
@@ -32,12 +32,14 @@ type apiErrorMsg struct {
 // HTTPError represents an error from the Coder API.
 type HTTPError struct {
 	*http.Response
-	cached    *apiError
+	cached    *APIError
 	cachedErr error
 }
 
-func (e *HTTPError) Payload() (*apiError, error) {
-	var msg apiError
+// Payload decode the response body into the standard error structure. The `details`
+// section is stored as a raw json, and type depends on the `code` field.
+func (e *HTTPError) Payload() (*APIError, error) {
+	var msg APIError
 	if e.cached != nil || e.cachedErr != nil {
 		return e.cached, e.cachedErr
 	}

--- a/coder-sdk/error.go
+++ b/coder-sdk/error.go
@@ -24,24 +24,43 @@ type apiError struct {
 
 // apiErrorMsg contains the rich error information returned by API errors.
 type apiErrorMsg struct {
-	Msg string `json:"msg"`
+	Msg     string          `json:"msg"`
+	Code    string          `json:"code"`
+	Details json.RawMessage `json:"details"`
 }
 
 // HTTPError represents an error from the Coder API.
 type HTTPError struct {
 	*http.Response
+	cached    *apiError
+	cachedErr error
+}
+
+func (e *HTTPError) Payload() (*apiError, error) {
+	var msg apiError
+	if e.cached != nil || e.cachedErr != nil {
+		return e.cached, e.cachedErr
+	}
+
+	// Try to decode the payload as an error, if it fails or if there is no error message,
+	// return the response URL with the status.
+	if err := json.NewDecoder(e.Response.Body).Decode(&msg); err != nil {
+		e.cachedErr = err
+		return nil, err
+	}
+
+	e.cached = &msg
+	return &msg, nil
 }
 
 func (e *HTTPError) Error() string {
-	var msg apiError
-	// Try to decode the payload as an error, if it fails or if there is no error message,
-	// return the response URL with the status.
-	if err := json.NewDecoder(e.Response.Body).Decode(&msg); err != nil || msg.Err.Msg == "" {
+	apiErr, err := e.Payload()
+	if err != nil || apiErr.Err.Msg == "" {
 		return fmt.Sprintf("%s: %d %s", e.Request.URL, e.StatusCode, e.Status)
 	}
 
 	// If the payload was a in the expected error format with a message, include it.
-	return msg.Err.Msg
+	return apiErr.Err.Msg
 }
 
 func bodyError(resp *http.Response) error {

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -397,7 +397,7 @@ coder envs create-from-config -f coder.yaml`,
 	return cmd
 }
 
-// handleTemplateError attempts to convert the basic error into a more detailed clog error
+// handleTemplateError attempts to convert the basic error into a more detailed clog error.
 func handleTemplateError(origError error) error {
 	var httpError *coder.HTTPError
 	if !xerrors.As(origError, &httpError) {

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -408,8 +408,8 @@ func handleTemplateError(origError error) error {
 		return origError
 	}
 
-	switch ae.Err.Code {
-	case "wac_template":
+	// TODO: Handle verbose case here too?
+	if ae.Err.Code == "wac_template" {
 		type payload struct {
 			ErrorType string   `json:"error_type"`
 			Msgs      []string `json:"messages"`

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -397,15 +397,16 @@ coder envs create-from-config -f coder.yaml`,
 	return cmd
 }
 
+// handleTemplateError attempts to convert the basic error into a more detailed clog error
 func handleTemplateError(origError error) error {
 	var httpError *coder.HTTPError
 	if !xerrors.As(origError, &httpError) {
-		return origError
+		return origError // Return the original
 	}
 
 	ae, err := httpError.Payload()
 	if err != nil {
-		return origError
+		return origError // Return the original
 	}
 
 	// TODO: Handle verbose case here too?
@@ -423,7 +424,8 @@ func handleTemplateError(origError error) error {
 
 		return clog.Error(p.ErrorType, p.Msgs...)
 	}
-	return origError
+
+	return origError // Return the original
 }
 
 func editEnvCmd() *cobra.Command {

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"golang.org/x/xerrors"
 
@@ -47,6 +48,23 @@ func handleAPIError(origError error) error {
 		}
 
 		return clog.Error(origError.Error(), p.Verbose)
+	case "precondition":
+		type preconditionPayload struct {
+			Error    string `json:"error"`
+			Message  string `json:"message"`
+			Solution string `json:"solution"`
+		}
+
+		var p preconditionPayload
+		err := json.Unmarshal(ae.Err.Details, &p)
+		if err != nil {
+			return origError
+		}
+
+		return clog.Error(fmt.Sprintf("Precondition Error : Status Code=%d", httpError.StatusCode),
+			p.Message,
+			clog.BlankLine,
+			clog.Tipf(p.Solution))
 	}
 
 	return origError // Return the original

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"encoding/json"
 
+	"golang.org/x/xerrors"
+
 	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/coder-cli/pkg/clog"
-	"golang.org/x/xerrors"
 )
 
 // handleAPIError attempts to convert an api error into a more detailed clog error.
-// If it cannot, it will return the original error
+// If it cannot, it will return the original error.
 func handleAPIError(origError error) error {
 	var httpError *coder.HTTPError
 	if !xerrors.As(origError, &httpError) {

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"encoding/json"
+
+	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/pkg/clog"
+	"golang.org/x/xerrors"
+)
+
+// handleAPIError attempts to convert an api error into a more detailed clog error.
+// If it cannot, it will return the original error
+func handleAPIError(origError error) error {
+	var httpError *coder.HTTPError
+	if !xerrors.As(origError, &httpError) {
+		return origError // Return the original
+	}
+
+	ae, err := httpError.Payload()
+	if err != nil {
+		return origError // Return the original
+	}
+
+	switch ae.Err.Code {
+	case "wac_template": // template parse errors
+		type templatePayload struct {
+			ErrorType string   `json:"error_type"`
+			Msgs      []string `json:"messages"`
+		}
+
+		var p templatePayload
+		err := json.Unmarshal(ae.Err.Details, &p)
+		if err != nil {
+			return origError
+		}
+
+		return clog.Error(p.ErrorType, p.Msgs...)
+	case "verbose":
+		type verbosePayload struct {
+			Verbose string `json:"verbose"`
+		}
+		var p verbosePayload
+		err := json.Unmarshal(ae.Err.Details, &p)
+		if err != nil {
+			return origError
+		}
+
+		return clog.Error(origError.Error(), p.Verbose)
+	}
+
+	return origError // Return the original
+}


### PR DESCRIPTION
Related to: https://github.com/cdr/m/pull/7373

In addition to the errors reported in the `/m` pr, this also now expands verbose errors. These verbose errors are not yet reviewed for human readability:


## 404 Repo

```
error: unexpected status code 500: An internal server error occurred.
  | read file: get file contents: GET https://api.github.com/repos/Emyrk/te/contents/.coder/coder.yaml?ref=master: 404 Not Found []
```

## Empty Request

```
error: unexpected status code 500: An internal server error occurred.
  | parse repo url: unexpected url "", expecting at least an owner and a repo
```

## Any server internal error

```
error: unexpected status code 500: An internal server error occurred.
  | exec select: pq: relation "images" does not exist
```