### PR TITLE
chore: limit direct uses of os.Stdout/os.Stderr/os.Stdin

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
@@ -106,13 +104,13 @@ $ coder completion fish > ~/.config/fish/completions/coder.fish
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":
-				_ = cmd.Root().GenBashCompletion(os.Stdout) // Best effort.
+				_ = cmd.Root().GenBashCompletion(cmd.OutOrStdout()) // Best effort.
 			case "zsh":
-				_ = cmd.Root().GenZshCompletion(os.Stdout) // Best effort.
+				_ = cmd.Root().GenZshCompletion(cmd.OutOrStdout()) // Best effort.
 			case "fish":
-				_ = cmd.Root().GenFishCompletion(os.Stdout, true) // Best effort.
+				_ = cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true) // Best effort.
 			case "powershell":
-				_ = cmd.Root().GenPowerShellCompletion(os.Stdout) // Best effort.
+				_ = cmd.Root().GenPowerShellCompletion(cmd.OutOrStdout()) // Best effort.
 			}
 		},
 	}

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/url"
-	"os"
 
 	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/coder-cli/internal/coderutil"
@@ -82,7 +81,7 @@ func lsEnvsCommand() *cobra.Command {
 					return xerrors.Errorf("write table: %w", err)
 				}
 			case jsonOutput:
-				err := json.NewEncoder(os.Stdout).Encode(envs)
+				err := json.NewEncoder(cmd.OutOrStdout()).Encode(envs)
 				if err != nil {
 					return xerrors.Errorf("write environments as JSON: %w", err)
 				}

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -62,7 +61,7 @@ func lsImgsCommand(user *string) *cobra.Command {
 
 			switch outputFmt {
 			case jsonOutput:
-				enc := json.NewEncoder(os.Stdout)
+				enc := json.NewEncoder(cmd.OutOrStdout())
 				// pretty print the json
 				enc.SetIndent("", "\t")
 

--- a/internal/cmd/rebuild.go
+++ b/internal/cmd/rebuild.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/coder-cli/coder-sdk"
@@ -85,7 +83,7 @@ func trailBuildLogs(ctx context.Context, client coder.Client, envID string) erro
 	newSpinner := func() *spinner.Spinner { return spinner.New(spinner.CharSets[11], 100*time.Millisecond) }
 
 	// this tells us whether to show dynamic loaders when printing output
-	isTerminal := terminal.IsTerminal(int(os.Stdout.Fd()))
+	isTerminal := showInteractiveOutput
 
 	logs, err := client.FollowEnvironmentBuildLog(ctx, envID)
 	if err != nil {

--- a/internal/cmd/resourcemanager.go
+++ b/internal/cmd/resourcemanager.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"text/tabwriter"
 
@@ -96,7 +95,7 @@ func runResourceTop(options *resourceTopOptions) func(cmd *cobra.Command, args [
 			return xerrors.Errorf("unknown --group %q", options.group)
 		}
 
-		return printResourceTop(os.Stdout, groups, labeler, options.showEmptyGroups, options.sortBy)
+		return printResourceTop(cmd.OutOrStdout(), groups, labeler, options.showEmptyGroups, options.sortBy)
 	}
 }
 

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -90,11 +90,15 @@ func makeRunSync(init *bool) func(cmd *cobra.Command, args []string) error {
 		}
 
 		s := sync.Sync{
-			Init:      *init,
-			Env:       *env,
-			RemoteDir: remoteDir,
-			LocalDir:  absLocal,
-			Client:    client,
+			Init:                *init,
+			Env:                 *env,
+			RemoteDir:           remoteDir,
+			LocalDir:            absLocal,
+			Client:              client,
+			OutW:                cmd.OutOrStdout(),
+			ErrW:                cmd.ErrOrStderr(),
+			InputReader:         cmd.InOrStdin(),
+			IsInteractiveOutput: showInteractiveOutput,
 		}
 
 		localVersion := rsyncVersion()

--- a/internal/cmd/tags.go
+++ b/internal/cmd/tags.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -113,7 +112,7 @@ func tagsLsCmd() *cobra.Command {
 					return err
 				}
 			case jsonOutput:
-				err := json.NewEncoder(os.Stdout).Encode(tags)
+				err := json.NewEncoder(cmd.OutOrStdout()).Encode(tags)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -56,7 +55,7 @@ func lsTokensCmd() *cobra.Command {
 					return xerrors.Errorf("write table: %w", err)
 				}
 			case jsonOutput:
-				err := json.NewEncoder(os.Stdout).Encode(tokens)
+				err := json.NewEncoder(cmd.OutOrStdout()).Encode(tokens)
 				if err != nil {
 					return xerrors.Errorf("write tokens as JSON: %w", err)
 				}

--- a/internal/cmd/urls.go
+++ b/internal/cmd/urls.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -107,7 +106,7 @@ func listDevURLsCmd(outputFmt *string) func(cmd *cobra.Command, args []string) e
 				return xerrors.Errorf("write table: %w", err)
 			}
 		case jsonOutput:
-			if err := json.NewEncoder(os.Stdout).Encode(devURLs); err != nil {
+			if err := json.NewEncoder(cmd.OutOrStdout()).Encode(devURLs); err != nil {
 				return xerrors.Errorf("encode DevURLs as json: %w", err)
 			}
 		default:

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -51,7 +50,7 @@ func listUsers(outputFmt *string) func(cmd *cobra.Command, args []string) error 
 				return xerrors.Errorf("write table: %w", err)
 			}
 		case "json":
-			if err := json.NewEncoder(os.Stdout).Encode(users); err != nil {
+			if err := json.NewEncoder(cmd.OutOrStdout()).Encode(users); err != nil {
 				return xerrors.Errorf("encode users as json: %w", err)
 			}
 		default:

--- a/internal/sync/title.go
+++ b/internal/sync/title.go
@@ -2,14 +2,11 @@ package sync
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
-
-	"golang.org/x/crypto/ssh/terminal"
 )
 
-func setConsoleTitle(title string) {
-	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+func setConsoleTitle(title string, isInteractiveOutput bool) {
+	if !isInteractiveOutput {
 		return
 	}
 	fmt.Printf("\033]0;%s\007", title)

--- a/pkg/clog/clog.go
+++ b/pkg/clog/clog.go
@@ -3,12 +3,20 @@ package clog
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
 	"github.com/fatih/color"
 	"golang.org/x/xerrors"
 )
+
+var writer io.Writer = os.Stderr
+
+// SetOutput sets the package-level writer target for log functions.
+func SetOutput(w io.Writer) {
+	writer = w
+}
 
 // CLIMessage provides a human-readable message for CLI errors and messages.
 type CLIMessage struct {
@@ -45,12 +53,12 @@ func Log(err error) {
 	if !xerrors.As(err, &cliErr) {
 		cliErr = Fatal(err.Error())
 	}
-	fmt.Fprintln(os.Stderr, cliErr.String())
+	fmt.Fprintln(writer, cliErr.String())
 }
 
 // LogInfo prints the given info message to stderr.
 func LogInfo(header string, lines ...string) {
-	fmt.Fprint(os.Stderr, CLIMessage{
+	fmt.Fprint(writer, CLIMessage{
 		Level:  "info",
 		Color:  color.FgBlue,
 		Header: header,
@@ -60,7 +68,7 @@ func LogInfo(header string, lines ...string) {
 
 // LogSuccess prints the given info message to stderr.
 func LogSuccess(header string, lines ...string) {
-	fmt.Fprint(os.Stderr, CLIMessage{
+	fmt.Fprint(writer, CLIMessage{
 		Level:  "success",
 		Color:  color.FgGreen,
 		Header: header,
@@ -70,7 +78,7 @@ func LogSuccess(header string, lines ...string) {
 
 // LogWarn prints the given warn message to stderr.
 func LogWarn(header string, lines ...string) {
-	fmt.Fprint(os.Stderr, CLIMessage{
+	fmt.Fprint(writer, CLIMessage{
 		Level:  "warning",
 		Color:  color.FgYellow,
 		Header: header,

--- a/pkg/clog/clog_test.go
+++ b/pkg/clog/clog_test.go
@@ -20,7 +20,7 @@ func TestError(t *testing.T) {
 		assert.Success(t, "create pipe", err)
 
 		//! clearly not thread safe
-		os.Stderr = writer
+		SetOutput(writer)
 
 		Log(mockErr)
 		writer.Close()
@@ -39,7 +39,7 @@ func TestError(t *testing.T) {
 		assert.Success(t, "create pipe", err)
 
 		//! clearly not thread safe
-		os.Stderr = writer
+		SetOutput(writer)
 
 		Log(mockErr)
 		writer.Close()
@@ -59,7 +59,7 @@ func TestError(t *testing.T) {
 		assert.Success(t, "create pipe", err)
 
 		//! clearly not thread safe
-		os.Stderr = writer
+		SetOutput(writer)
 
 		Log(mockErr)
 		writer.Close()


### PR DESCRIPTION
By moving the out/err/in channels to the cobra config,
it will be easier to add fast and isolated unit tests.
