### PR TITLE
feature: support filtering by workspace provider when listing environ…

### DIFF
--- a/ci/integration/envs_test.go
+++ b/ci/integration/envs_test.go
@@ -144,6 +144,20 @@ func TestEnvsCLI(t *testing.T) {
 			tcli.StdoutMatches(regexp.QuoteMeta(name)),
 		)
 
+		// filter by provider that does not exist should fail
+		doesntExist := randString(10)
+		c.Run(ctx, fmt.Sprintf("coder envs ls --provider %s", doesntExist)).Assert(t,
+			tcli.Error(),
+			tcli.StderrMatches(regexp.QuoteMeta(fmt.Sprintf("fatal: no environments found for workspace provider %q", doesntExist))),
+		)
+
+		// filter by provider that does exist should succeed
+		var envs []coder.Environment
+		c.Run(ctx, "coder envs ls --provider built-in").Assert(t,
+			tcli.Success(),
+			tcli.StdoutJSONUnmarshal(&envs),
+		)
+
 		var env coder.Environment
 		c.Run(ctx, fmt.Sprintf(`coder envs ls -o json | jq '.[] | select(.name == "%s")'`, name)).Assert(t,
 			tcli.Success(),

--- a/ci/integration/envs_test.go
+++ b/ci/integration/envs_test.go
@@ -144,20 +144,6 @@ func TestEnvsCLI(t *testing.T) {
 			tcli.StdoutMatches(regexp.QuoteMeta(name)),
 		)
 
-		// filter by provider that does not exist should fail
-		doesntExist := randString(10)
-		c.Run(ctx, fmt.Sprintf("coder envs ls --provider %s", doesntExist)).Assert(t,
-			tcli.Error(),
-			tcli.StderrMatches(regexp.QuoteMeta(fmt.Sprintf("fatal: no environments found for workspace provider %q", doesntExist))),
-		)
-
-		// filter by provider that does exist should succeed
-		var envs []coder.Environment
-		c.Run(ctx, "coder envs ls --provider built-in").Assert(t,
-			tcli.Success(),
-			tcli.StdoutJSONUnmarshal(&envs),
-		)
-
 		var env coder.Environment
 		c.Run(ctx, fmt.Sprintf(`coder envs ls -o json | jq '.[] | select(.name == "%s")'`, name)).Assert(t,
 			tcli.Success(),

--- a/coder-sdk/env.go
+++ b/coder-sdk/env.go
@@ -339,6 +339,7 @@ func (c *DefaultClient) EnvironmentByID(ctx context.Context, id string) (*Enviro
 	return &env, nil
 }
 
+// EnvironmentsByWorkspaceProvider returns all environments that belong to a particular workspace provider.
 func (c *DefaultClient) EnvironmentsByWorkspaceProvider(ctx context.Context, wpID string) ([]Environment, error) {
 	var envs []Environment
 	if err := c.requestBody(ctx, http.MethodGet, "/api/private/resource-pools/"+wpID+"/environments", nil, &envs); err != nil {

--- a/coder-sdk/env.go
+++ b/coder-sdk/env.go
@@ -338,3 +338,11 @@ func (c *DefaultClient) EnvironmentByID(ctx context.Context, id string) (*Enviro
 	}
 	return &env, nil
 }
+
+func (c *DefaultClient) EnvironmentsByWorkspaceProvider(ctx context.Context, wpID string) ([]Environment, error) {
+	var envs []Environment
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/resource-pools/"+wpID+"/environments/", nil, &envs); err != nil {
+		return nil, err
+	}
+	return envs, nil
+}

--- a/coder-sdk/env.go
+++ b/coder-sdk/env.go
@@ -341,7 +341,7 @@ func (c *DefaultClient) EnvironmentByID(ctx context.Context, id string) (*Enviro
 
 func (c *DefaultClient) EnvironmentsByWorkspaceProvider(ctx context.Context, wpID string) ([]Environment, error) {
 	var envs []Environment
-	if err := c.requestBody(ctx, http.MethodGet, "/api/private/resource-pools/"+wpID+"/environments/", nil, &envs); err != nil {
+	if err := c.requestBody(ctx, http.MethodGet, "/api/private/resource-pools/"+wpID+"/environments", nil, &envs); err != nil {
 		return nil, err
 	}
 	return envs, nil

--- a/coder-sdk/interface.go
+++ b/coder-sdk/interface.go
@@ -130,6 +130,9 @@ type Client interface {
 	// EnvironmentByID get the details of an environment by its id.
 	EnvironmentByID(ctx context.Context, id string) (*Environment, error)
 
+	// EnvironmentsByWorkspaceProvider returns environments that belong to a particular workspace provider.
+	EnvironmentsByWorkspaceProvider(ctx context.Context, wpID string) ([]Environment, error)
+
 	// ImportImage creates a new image and optionally a new registry.
 	ImportImage(ctx context.Context, req ImportImageReq) (*Image, error)
 

--- a/docs/coder_envs_ls.md
+++ b/docs/coder_envs_ls.md
@@ -13,9 +13,10 @@ coder envs ls [flags]
 ### Options
 
 ```
-  -h, --help            help for ls
-  -o, --output string   human | json (default "human")
-      --user string     Specify the user whose resources to target (default "me")
+  -h, --help              help for ls
+  -o, --output string     human | json (default "human")
+  -p, --provider string   Filter environments by a particular workspace provider name.
+      --user string       Specify the user whose resources to target (default "me")
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/ceapi.go
+++ b/internal/cmd/ceapi.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/coder-cli/coder-sdk"
+	"cdr.dev/coder-cli/internal/coderutil"
 	"cdr.dev/coder-cli/pkg/clog"
 )
 
@@ -203,22 +204,8 @@ func getUserOrgs(ctx context.Context, client coder.Client, email string) ([]code
 	return lookupUserOrgs(u, orgs), nil
 }
 
-func getProviderByName(ctx context.Context, client coder.Client, wpName string) (*coder.KubernetesProvider, error) {
-	providers, err := client.WorkspaceProviders(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, provider := range providers.Kubernetes {
-		if provider.Name == wpName {
-			return &provider, nil
-		}
-	}
-	return nil, xerrors.Errorf("workspace provider %q not found", wpName)
-}
-
 func getEnvsByProvider(ctx context.Context, client coder.Client, wpName string) ([]coder.Environment, error) {
-	wp, err := getProviderByName(ctx, client, wpName)
+	wp, err := coderutil.ProviderByName(ctx, client, wpName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/ceapi.go
+++ b/internal/cmd/ceapi.go
@@ -204,7 +204,7 @@ func getUserOrgs(ctx context.Context, client coder.Client, email string) ([]code
 	return lookupUserOrgs(u, orgs), nil
 }
 
-func getEnvsByProvider(ctx context.Context, client coder.Client, wpName string) ([]coder.Environment, error) {
+func getEnvsByProvider(ctx context.Context, client coder.Client, wpName, userEmail string) ([]coder.Environment, error) {
 	wp, err := coderutil.ProviderByName(ctx, client, wpName)
 	if err != nil {
 		return nil, err
@@ -214,5 +214,25 @@ func getEnvsByProvider(ctx context.Context, client coder.Client, wpName string) 
 	if err != nil {
 		return nil, err
 	}
+
+	envs, err = filterEnvsByUser(ctx, client, userEmail, envs)
+	if err != nil {
+		return nil, err
+	}
 	return envs, nil
+}
+
+func filterEnvsByUser(ctx context.Context, client coder.Client, userEmail string, envs []coder.Environment) ([]coder.Environment, error) {
+	user, err := client.UserByEmail(ctx, userEmail)
+	if err != nil {
+		return nil, xerrors.Errorf("get user: %w", err)
+	}
+
+	var filteredEnvs []coder.Environment
+	for _, env := range envs {
+		if env.UserID == user.ID {
+			filteredEnvs = append(filteredEnvs, env)
+		}
+	}
+	return filteredEnvs, nil
 }

--- a/internal/cmd/ceapi.go
+++ b/internal/cmd/ceapi.go
@@ -202,3 +202,30 @@ func getUserOrgs(ctx context.Context, client coder.Client, email string) ([]code
 	}
 	return lookupUserOrgs(u, orgs), nil
 }
+
+func getProviderByName(ctx context.Context, client coder.Client, wpName string) (*coder.KubernetesProvider, error) {
+	providers, err := client.WorkspaceProviders(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, provider := range providers.Kubernetes {
+		if provider.Name == wpName {
+			return &provider, nil
+		}
+	}
+	return nil, xerrors.Errorf("workspace provider %q not found", wpName)
+}
+
+func getEnvsByProvider(ctx context.Context, client coder.Client, wpName string) ([]coder.Environment, error) {
+	wp, err := getProviderByName(ctx, client, wpName)
+	if err != nil {
+		return nil, err
+	}
+
+	envs, err := client.EnvironmentsByWorkspaceProvider(ctx, wp.ID)
+	if err != nil {
+		return nil, err
+	}
+	return envs, nil
+}

--- a/internal/cmd/cli_test.go
+++ b/internal/cmd/cli_test.go
@@ -114,6 +114,7 @@ func (r result) clogError(t *testing.T) clog.CLIError {
 	return cliErr
 }
 
+//nolint
 func execute(t *testing.T, in io.Reader, args ...string) result {
 	cmd := Make()
 

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -51,6 +51,7 @@ func lsEnvsCommand() *cobra.Command {
 	var (
 		outputFmt string
 		user      string
+		provider  string
 	)
 
 	cmd := &cobra.Command{
@@ -66,6 +67,12 @@ func lsEnvsCommand() *cobra.Command {
 			envs, err := getEnvs(ctx, client, user)
 			if err != nil {
 				return err
+			}
+			if provider != "" {
+				envs, err = getEnvsByProvider(ctx, client, provider)
+				if err != nil {
+					return err
+				}
 			}
 			if len(envs) < 1 {
 				clog.LogInfo("no environments found")
@@ -94,6 +101,7 @@ func lsEnvsCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&user, "user", coder.Me, "Specify the user whose resources to target")
 	cmd.Flags().StringVarP(&outputFmt, "output", "o", humanOutput, "human | json")
+	cmd.Flags().StringVarP(&provider, "provider", "p", "", "Filter environments by a particular workspace provider name.")
 
 	return cmd
 }

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -69,7 +69,7 @@ func lsEnvsCommand() *cobra.Command {
 				return err
 			}
 			if provider != "" {
-				envs, err = getEnvsByProvider(ctx, client, provider)
+				envs, err = getEnvsByProvider(ctx, client, provider, user)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/envs_test.go
+++ b/internal/cmd/envs_test.go
@@ -16,3 +16,29 @@ func Test_envs_ls(t *testing.T) {
 	var envs []coder.Environment
 	res.stdoutUnmarshals(t, &envs)
 }
+
+func Test_envs_ls_by_provider(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		command []string
+		assert  func(r result)
+	}{
+		{
+			name:    "simple list",
+			command: []string{"envs", "ls", "--provider", "built-in"},
+			assert:  func(r result) { r.success(t) },
+		},
+		{
+			name:    "list as json",
+			command: []string{"envs", "ls", "--provider", "built-in", "--output", "json"},
+			assert: func(r result) {
+				var envs []coder.Environment
+				r.stdoutUnmarshals(t, &envs)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			test.assert(execute(t, nil, test.command...))
+		})
+	}
+}

--- a/internal/cmd/envs_test.go
+++ b/internal/cmd/envs_test.go
@@ -17,6 +17,7 @@ func Test_envs_ls(t *testing.T) {
 	res.stdoutUnmarshals(t, &envs)
 }
 
+//nolint
 func Test_envs_ls_by_provider(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/internal/cmd/resourcemanager.go
+++ b/internal/cmd/resourcemanager.go
@@ -161,16 +161,16 @@ func aggregateByProvider(providers []coder.KubernetesProvider, orgs []coder.Orga
 	}
 	providerEnvs := make(map[string][]coder.Environment, len(orgs))
 	for _, e := range envs {
-		if options.user != "" && providerIDMap[e.ResourcePoolID].Name != options.provider {
+		if options.provider != "" && providerIDMap[e.ResourcePoolID].Name != options.provider {
 			continue
 		}
-		providerEnvs[e.OrganizationID] = append(providerEnvs[e.OrganizationID], e)
+		providerEnvs[e.ResourcePoolID] = append(providerEnvs[e.ResourcePoolID], e)
 	}
-	for _, o := range orgs {
-		if options.org != "" && o.Name != options.org {
+	for _, p := range providers {
+		if options.provider != "" && p.Name != options.provider {
 			continue
 		}
-		groups = append(groups, orgGrouping{org: o, envs: providerEnvs[o.ID]})
+		groups = append(groups, providerGrouping{provider: p, envs: providerEnvs[p.ID]})
 	}
 	return groups, providerLabeler{providerIDMap}
 }
@@ -209,6 +209,19 @@ func (o orgGrouping) header() string {
 		plural = ""
 	}
 	return fmt.Sprintf("%s\t(%v member%s)", truncate(o.org.Name, 20, "..."), len(o.org.Members), plural)
+}
+
+type providerGrouping struct {
+	provider coder.KubernetesProvider
+	envs     []coder.Environment
+}
+
+func (p providerGrouping) environments() []coder.Environment {
+	return p.envs
+}
+
+func (p providerGrouping) header() string {
+	return fmt.Sprintf("%s\t", truncate(p.provider.Name, 20, "..."))
 }
 
 func printResourceTop(writer io.Writer, groups []groupable, labeler envLabeler, showEmptyGroups bool, sortBy string) error {

--- a/internal/cmd/resourcemanager.go
+++ b/internal/cmd/resourcemanager.go
@@ -337,7 +337,7 @@ type providerLabeler struct {
 }
 
 func (p providerLabeler) label(e coder.Environment) string {
-	return fmt.Sprintf("[provider %s]", p.providerMap[e.ResourcePoolID].Name)
+	return fmt.Sprintf("[provider: %s]", p.providerMap[e.ResourcePoolID].Name)
 }
 
 func aggregateEnvResources(envs []coder.Environment) resources {


### PR DESCRIPTION
# What this does?

Adds the `--provider` flag to both the `coder envs ls` command as well as the `coder resources top` command.

## envs command

Now supports the `--provider` flag so users can filter environments by a particular workspace provider name.

<img width="492" alt="Screenshot 2021-03-11 at 3 22 46 PM" src="https://user-images.githubusercontent.com/34631293/110857052-fbaeec80-827d-11eb-8dde-f93941414fcf.png">

## resource manager command

Now supports the `--provider` flag so users can aggregate resource amounts by a particular workspace provider name.

<img width="482" alt="Screenshot 2021-03-11 at 3 52 41 PM" src="https://user-images.githubusercontent.com/34631293/110859991-d9b76900-8281-11eb-88ef-16d421897c0e.png">
