### PR TITLE
Add documentation after provider create

### DIFF
--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -91,6 +91,9 @@ helm upgrade coder-workspace-provider coder/workspace-provider \
     --set envproxy.clusterAddress=`+clusterAddress+` \
     --set cemanager.AccessURL=`+cemanagerURL.String()+`
 
+WARNING: The 'envproxy.token' is a secret value that authenticates the workspace provider, 
+make sure not to share this token or make it public. 
+
 Other values can be set on the helm chart to further customize the deployment, see 
 https:/github.com/cdr/enterprise-helm/blob/workspace-providers-envproxy-only/README.md
 `)

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -63,12 +63,38 @@ coder providers create my-provider --hostname=https://provider.example.com --clu
 				return xerrors.Errorf("create workspace provider: %w", err)
 			}
 
-			err = tablewriter.WriteTable(cmd.OutOrStdout(), 1, func(i int) interface{} {
+			cemanagerURL := client.BaseURL()
+			version, err := client.APIVersion(ctx)
+			if err != nil {
+				return xerrors.Errorf("get application version: %w", err)
+			}
+
+			clog.LogSuccess(fmt.Sprintf(`
+Created workspace provider "%s"
+`, createReq.Name))
+			_ = tablewriter.WriteTable(cmd.OutOrStdout(), 1, func(i int) interface{} {
 				return *wp
 			})
-			if err != nil {
-				return xerrors.Errorf("write table: %w", err)
-			}
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), `
+Now that the workspace provider is provisioned, it must be deployed into the cluster. To learn more,
+visit https://coder.com/docs/guides/deploying-workspace-provider
+
+When connected to the cluster you wish to deploy onto, use the following helm command:
+
+helm upgrade coder-workspace-provider coder/workspace-provider \
+    --version=`+version+` \
+    --atomic \
+    --install \
+    --force \
+    --set envproxy.token=`+wp.EnvproxyToken+` \
+    --set ingress.host=`+hostname+` \
+    --set envproxy.clusterAddress=`+clusterAddress+` \
+    --set cemanager.AccessURL=`+cemanagerURL.String()+`
+
+Other values can be set on the helm chart to further customize the deployment, see 
+https:/github.com/cdr/enterprise-helm/blob/workspace-providers-envproxy-only/README.md
+`)
+
 			return nil
 		},
 	}


### PR DESCRIPTION
Example:
```
➜  coder-cli git:(master) ✗ go run cmd/coder/main.go providers create cli-test-2 --hostname=http://cli-test.master.cdr.dev --cluster-address=https://104.154.56.145
success: 
Created workspace provider "cli-test-2"

ID                                   Name          Status     Envproxy Token                       
604aca11-5f959b6c46fe9ef188a621b3    cli-test-2    pending    604aca11-5fc1688feae792c669d130b3    

Now that the workspace provider is provisioned, it must be deployed into the cluster. To learn more,
visit https://coder.com/docs/guides/deploying-workspace-provider

When connected to the cluster you wish to deploy onto, use the following helm command:

helm upgrade coder-workspace-provider coder/workspace-provider \
    --version=1.17.0-rc.1+27-g0c229ed3a-20210311 \
    --atomic \
    --install \
    --force \
    --set envproxy.token=604aca11-5fc1688feae792c669d130b3 \
    --set ingress.host=http://cli-test.master.cdr.dev \
    --set envproxy.clusterAddress=https://104.154.56.145 \
    --set cemanager.AccessURL=https://master.cdr.dev

WARNING: The 'envproxy.token' is a secret value that authenticates the workspace provider, 
make sure not to share this token or make it public. 

Other values can be set on the helm chart to further customize the deployment, see 
https:/github.com/cdr/enterprise-helm/blob/workspace-providers-envproxy-only/README.md
```
WIP Doc link: https://codercom-2dho4qoqj-codercom.vercel.app/docs/guides/deploying-workspace-provider