### PR TITLE
fix: wrong len arg in provider aggregator

### DIFF
--- a/internal/cmd/resourcemanager.go
+++ b/internal/cmd/resourcemanager.go
@@ -153,7 +153,7 @@ func aggregateByOrg(users []coder.User, orgs []coder.Organization, envs []coder.
 	return groups, userLabeler{userIDMap}
 }
 
-func aggregateByProvider(providers []coder.KubernetesProvider, orgs []coder.Organization, envs []coder.Environment, options resourceTopOptions) ([]groupable, envLabeler) {
+func aggregateByProvider(providers []coder.KubernetesProvider, _ []coder.Organization, envs []coder.Environment, options resourceTopOptions) ([]groupable, envLabeler) {
 	var groups []groupable
 	providerIDMap := make(map[string]coder.KubernetesProvider)
 	for _, p := range providers {

--- a/internal/cmd/resourcemanager.go
+++ b/internal/cmd/resourcemanager.go
@@ -159,7 +159,7 @@ func aggregateByProvider(providers []coder.KubernetesProvider, orgs []coder.Orga
 	for _, p := range providers {
 		providerIDMap[p.ID] = p
 	}
-	providerEnvs := make(map[string][]coder.Environment, len(orgs))
+	providerEnvs := make(map[string][]coder.Environment, len(providers))
 	for _, e := range envs {
 		if options.provider != "" && providerIDMap[e.ResourcePoolID].Name != options.provider {
 			continue


### PR DESCRIPTION
# What this does?

Fixes the `len` of the `providerEnvs` map in the grouping func when filtering by providers.