### PR TITLE
chore: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,23 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-    time: "11:00"
-  open-pull-requests-limit: 10
-  ignore:
-    # GitHub always delivers the latest versions for each major
-    # release tag, so ignore minor version tags
-    - dependency-name: "actions/cache"
-      versions:
-        - 2.x
-    - dependency-name: "actions/checkout"
-      versions:
-        - 2.x
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "America/Chicago"
+    commit-message:
+      prefix: "chore"
+    ignore:
+      # GitHub always delivers the latest versions for each major
+      # release tag, so handle updates manually
+      - dependency-name: "actions/*"
 
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "America/Chicago"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
* Add commit message prefix
* Schedule updates at 6am Austin time instead of the default UTC
* Ignore updates for all official GitHub Actions
* Use the default pull request limit of 5 open PRs
* Format configuration file with Prettier