### PR TITLE
feat: add image:tag label to resources top

### DIFF
--- a/internal/cmd/resourcemanager.go
+++ b/internal/cmd/resourcemanager.go
@@ -165,7 +165,7 @@ func aggregateByOrg(providers []coder.KubernetesProvider, users []coder.User, or
 		}
 		groups = append(groups, orgGrouping{org: o, envs: orgEnvs[o.ID]})
 	}
-	return groups, labelAll(userLabeler(userIDMap), imgLabeler(images), providerLabeler(providerIDMap))
+	return groups, labelAll(imgLabeler(images), userLabeler(userIDMap), providerLabeler(providerIDMap))
 }
 
 func providerIDs(providers []coder.KubernetesProvider) map[string]coder.KubernetesProvider {
@@ -193,7 +193,7 @@ func aggregateByProvider(providers []coder.KubernetesProvider, users []coder.Use
 		}
 		groups = append(groups, providerGrouping{provider: p, envs: providerEnvs[p.ID]})
 	}
-	return groups, labelAll(userLabeler(userIDMap), imgLabeler(images)) // TODO: consider adding an org label here
+	return groups, labelAll(imgLabeler(images), userLabeler(userIDMap)) // TODO: consider adding an org label here
 }
 
 // groupable specifies a structure capable of being an aggregation group of environments (user, org, all).
@@ -398,7 +398,7 @@ type resources struct {
 
 func (a resources) String() string {
 	return fmt.Sprintf(
-		"[cpu: %.1fvCPU]\t[mem: %.1fGB]",
+		"[cpu: %.1f]\t[mem: %.1f GB]",
 		a.cpuAllocation, a.memAllocation,
 	)
 }

--- a/internal/cmd/resourcemanager.go
+++ b/internal/cmd/resourcemanager.go
@@ -418,6 +418,7 @@ func (a resources) String() string {
 	)
 }
 
+//nolint:unparam
 // truncate the given string and replace the removed chars with some replacement (ex: "...").
 func truncate(str string, max int, replace string) string {
 	if len(str) <= max {

--- a/internal/coderutil/env.go
+++ b/internal/coderutil/env.go
@@ -91,7 +91,7 @@ type EnvTable struct {
 
 // EnvsHumanTable performs the composition of each Environment with its associated ProviderName and ImageRepo.
 func EnvsHumanTable(ctx context.Context, client coder.Client, envs []coder.Environment) ([]EnvTable, error) {
-	imageMap, err := makeImageMap(ctx, client, envs)
+	imageMap, err := MakeImageMap(ctx, client, envs)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,8 @@ func EnvsHumanTable(ctx context.Context, client coder.Client, envs []coder.Envir
 	return pooledEnvs, nil
 }
 
-func makeImageMap(ctx context.Context, client coder.Client, envs []coder.Environment) (map[string]*coder.Image, error) {
+// MakeImageMap fetches all image entities specified in the slice of environments, then places them into an ID map.
+func MakeImageMap(ctx context.Context, client coder.Client, envs []coder.Environment) (map[string]*coder.Image, error) {
 	var (
 		mu     sync.Mutex
 		egroup = clog.LoggedErrGroup()


### PR DESCRIPTION
The verbose output does seem to have gotten quite wide... probably worth considering adding a `--label` flag where the caller can opt-in to labels. I removed the `alloc=` resource prefixes since those don't exactly make sense until we have `util` metrics. I'm not too worried though given that this is `hidden: True`.

```
# on test cluster
coder resources top --group org --verbose
Coder    (53 members)    [cpu: 128.0vCPU]    [mem: 144.0GB]
    dev                [cpu: 16.0vCPU]    [mem: 16.0GB]    [user: garrett@coder.com]     [img: coder-dogfood/master/enterprise-dev:latest]    [provider: built-in]
    dev                [cpu: 16.0vCPU]    [mem: 16.0GB]    [user: kyle@coder.com]        [img: coder-dogfood/master/enterprise-dev:latest]    [provider: built-in]
    jawnsy-m           [cpu: 16.0vCPU]    [mem: 16.0GB]    [user: jonathan@coder.com]    [img: coder-dogfood/master/enterprise-dev:latest]    [provider: built-in]
    kevinlint-coder    [cpu: 16.0vCPU]    [mem: 16.0GB]    [user: kevin@coder.com]       [img: coder-dogfood/master/enterprise-dev:latest]    [provider: built-in]
    my-dev-brazil      [cpu: 16.0vCPU]    [mem: 16.0GB]    [user: bruno@coder.com]       [img: coder-dogfood/master/enterprise-dev:latest]    [provider: brazil]
    grey-coder-us      [cpu: 16.0vCPU]    [mem: 16.0GB]    [user: grey@coder.com]        [img: coder-dogfood/master/enterprise-dev:latest]    [provider: us]
    cvm                [cpu: 16.0vCPU]    [mem: 16.0GB]    [user: ammar@coder.com]       [img: coder-dogfood/master/enterprise-dev:latest]    [provider: built-in]
    dev                [cpu: 16.0vCPU]    [mem: 32.0GB]    [user: faris@coder.com]       [img: coder-dogfood/master/enterprise-dev:latest]    [provider: built-in]

nathans-licensor-org    (1 member)    [cpu: 2.0vCPU]    [mem: 2.0GB]
    licensor    [cpu: 2.0vCPU]    [mem: 2.0GB]    [user: nathan@coder.com]    [img: codercom/enterprise-dev:latest]    [provider: built-in]

greysorg    (4 members)    [cpu: 1.0vCPU]    [mem: 1.0GB]
    grey-test-pycharm    [cpu: 1.0vCPU]    [mem: 1.0GB]    [user: grey@coder.com]    [img: codercom/enterprise-pycharm:ubuntu]    [provider: built-in]

```

cc @jmcampanini 