### PR TITLE
feat: implement cordon/uncordon workspace provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Coder CLI 
 
-.PHONY: clean build build/macos build/windows build/linux fmt lint gendocs test/go
+.PHONY: clean build build/macos build/windows build/linux fmt lint gendocs test/go dev
 
 PROJECT_ROOT := $(shell git rev-parse --show-toplevel)
 MAKE_ROOT := $(shell pwd)
@@ -42,3 +42,10 @@ test/coverage:
 		$$(go list ./... | grep -v pkg/tcli | grep -v ci/integration)
 
 	goveralls -coverprofile=coverage -service=github
+
+dev: build/linux
+	@echo "removing project root binary if exists"
+	-rm ./coder
+	@echo "untarring..."
+	@tar -xzf ./ci/bin/coder-cli-linux-amd64.tar.gz
+	@echo "new dev binary ready"

--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -100,14 +100,6 @@ func TestCoderCLI(t *testing.T) {
 		c.Run(ctx, "coder tokens ls").Assert(t,
 			tcli.Error(),
 		)
-
-		c.Run(ctx, "coder providers cordon --reason \"cloud cost\" built-in").Assert(t,
-			tcli.Success(),
-		)
-
-		c.Run(ctx, "coder providers uncordon built-in").Assert(t,
-			tcli.Success(),
-		)
 	})
 }
 

--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"cdr.dev/slog/sloggers/slogtest/assert"
 
+	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/coder-cli/pkg/tcli"
 )
 
@@ -99,6 +100,16 @@ func TestCoderCLI(t *testing.T) {
 
 		c.Run(ctx, "coder tokens ls").Assert(t,
 			tcli.Error(),
+		)
+
+		var updatedProvider coder.KubernetesProvider
+		c.Run(ctx, "coder providers cordon --reason \"cloud cost\" built-in").Assert(t,
+			tcli.Success(),
+			tcli.StdoutJSONUnmarshal(&updatedProvider),
+		)
+
+		c.Run(ctx, "coder providers uncordon built-in").Assert(t,
+			tcli.Success(),
 		)
 	})
 }

--- a/ci/integration/integration_test.go
+++ b/ci/integration/integration_test.go
@@ -8,7 +8,6 @@ import (
 
 	"cdr.dev/slog/sloggers/slogtest/assert"
 
-	"cdr.dev/coder-cli/coder-sdk"
 	"cdr.dev/coder-cli/pkg/tcli"
 )
 
@@ -102,10 +101,8 @@ func TestCoderCLI(t *testing.T) {
 			tcli.Error(),
 		)
 
-		var updatedProvider coder.KubernetesProvider
 		c.Run(ctx, "coder providers cordon --reason \"cloud cost\" built-in").Assert(t,
 			tcli.Success(),
-			tcli.StdoutJSONUnmarshal(&updatedProvider),
 		)
 
 		c.Run(ctx, "coder providers uncordon built-in").Assert(t,

--- a/coder-sdk/interface.go
+++ b/coder-sdk/interface.go
@@ -225,4 +225,10 @@ type Client interface {
 
 	// BaseURL returns the BaseURL configured for this Client.
 	BaseURL() url.URL
+
+	// CordonWorkspaceProvider prevents the provider from having any more workspaces placed on it.
+	CordonWorkspaceProvider(ctx context.Context, id, reason string) error
+
+	// UnCordonWorkspaceProvider prevents the provider from having any more workspaces placed on it.
+	UnCordonWorkspaceProvider(ctx context.Context, id string) error
 }

--- a/coder-sdk/interface.go
+++ b/coder-sdk/interface.go
@@ -229,6 +229,7 @@ type Client interface {
 	// CordonWorkspaceProvider prevents the provider from having any more workspaces placed on it.
 	CordonWorkspaceProvider(ctx context.Context, id, reason string) error
 
-	// UnCordonWorkspaceProvider prevents the provider from having any more workspaces placed on it.
+	// UnCordonWorkspaceProvider changes an existing cordoned providers status to 'Ready';
+	// allowing it to continue creating new workspaces and provisioning resources for them.
 	UnCordonWorkspaceProvider(ctx context.Context, id string) error
 }

--- a/coder-sdk/workspace_providers.go
+++ b/coder-sdk/workspace_providers.go
@@ -98,3 +98,27 @@ func (c *DefaultClient) CreateWorkspaceProvider(ctx context.Context, req CreateW
 func (c *DefaultClient) DeleteWorkspaceProviderByID(ctx context.Context, id string) error {
 	return c.requestBody(ctx, http.MethodDelete, "/api/private/resource-pools/"+id, nil, nil)
 }
+
+// CordoneWorkspaceProviderReq defines the request parameters for creating a new workspace provider entity.
+type CordoneWorkspaceProviderReq struct {
+	Reason string `json:"reason"`
+}
+
+// CordonWorkspaceProvider prevents the provider from having any more workspaces placed on it.
+func (c *DefaultClient) CordonWorkspaceProvider(ctx context.Context, id, reason string) error {
+	req := CordoneWorkspaceProviderReq{Reason: reason}
+	err := c.requestBody(ctx, http.MethodPost, "/api/private/resource-pools/"+id+"/cordon", req, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// UnCordonWorkspaceProvider prevents the provider from having any more workspaces placed on it.
+func (c *DefaultClient) UnCordonWorkspaceProvider(ctx context.Context, id string) error {
+	err := c.requestBody(ctx, http.MethodPost, "/api/private/resource-pools/"+id+"/uncordon", nil, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/coder-sdk/workspace_providers.go
+++ b/coder-sdk/workspace_providers.go
@@ -114,7 +114,8 @@ func (c *DefaultClient) CordonWorkspaceProvider(ctx context.Context, id, reason 
 	return nil
 }
 
-// UnCordonWorkspaceProvider prevents the provider from having any more workspaces placed on it.
+// UnCordonWorkspaceProvider changes an existing cordoned providers status to 'Ready';
+// allowing it to continue creating new workspaces and provisioning resources for them.
 func (c *DefaultClient) UnCordonWorkspaceProvider(ctx context.Context, id string) error {
 	err := c.requestBody(ctx, http.MethodPost, "/api/private/resource-pools/"+id+"/uncordon", nil, nil)
 	if err != nil {

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -224,6 +224,7 @@ func cordonProviderCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "cordon [workspace_provider_name]",
+		Args:  xcobra.ExactArgs(1),
 		Short: "cordon a workspace provider.",
 		Long:  "Prevent an existing Coder workspace provider from supporting any additional workspaces.",
 		Example: `# cordon an existing workspace provider by name
@@ -235,11 +236,17 @@ coder providers cordon my-workspace-provider --reason "limit cloud clost"`,
 				return err
 			}
 
-			provider, err := coderutil.ProviderByName(ctx, client, args[0])
+			wpName := args[0]
+			provider, err := coderutil.ProviderByName(ctx, client, wpName)
 			if err != nil {
 				return err
 			}
-			return client.CordonWorkspaceProvider(ctx, provider.ID, reason)
+
+			if err := client.CordonWorkspaceProvider(ctx, provider.ID, reason); err != nil {
+				return err
+			}
+			clog.LogSuccess(fmt.Sprintf("provider %q successfully cordoned - you can no longer create workspaces on this provider without uncordoning first", wpName))
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&reason, "reason", "", "reason for cordoning the provider")
@@ -250,6 +257,7 @@ coder providers cordon my-workspace-provider --reason "limit cloud clost"`,
 func unCordonProviderCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "uncordon [workspace_provider_name]",
+		Args:  xcobra.ExactArgs(1),
 		Short: "uncordon a workspace provider.",
 		Long:  "Set a currently cordoned provider as ready; enabling it to continue provisioning resources for new workspaces.",
 		Example: `# uncordon an existing workspace provider by name
@@ -261,11 +269,17 @@ coder providers uncordon my-workspace-provider`,
 				return err
 			}
 
-			provider, err := coderutil.ProviderByName(ctx, client, args[0])
+			wpName := args[0]
+			provider, err := coderutil.ProviderByName(ctx, client, wpName)
 			if err != nil {
 				return err
 			}
-			return client.UnCordonWorkspaceProvider(ctx, provider.ID)
+
+			if err := client.UnCordonWorkspaceProvider(ctx, provider.ID); err != nil {
+				return err
+			}
+			clog.LogSuccess(fmt.Sprintf("provider %q successfully cordoned - you can now create workspaces on this provider", wpName))
+			return nil
 		},
 	}
 	return cmd

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -278,7 +278,7 @@ coder providers uncordon my-workspace-provider`,
 			if err := client.UnCordonWorkspaceProvider(ctx, provider.ID); err != nil {
 				return err
 			}
-			clog.LogSuccess(fmt.Sprintf("provider %q successfully cordoned - you can now create workspaces on this provider", wpName))
+			clog.LogSuccess(fmt.Sprintf("provider %q successfully uncordoned - you can now create workspaces on this provider", wpName))
 			return nil
 		},
 	}


### PR DESCRIPTION
# What this does?

Implements two new subcommands.

## coder providers cordon

### Usage

`coder providers cordon --reason "cloud cost" provider-name`

Allows users to cordon a provider; preventing it from supporting new workspaces.

**Note** : the `--reason` flag is required to explain why this action was performed.

## coder providers uncordon

### Usage

`coder providers uncordon provider-name`

Also supports uncordoning a provider; allowing the provider to continue provisioning resources for new workspaces.

## Sample Output

<img width="1326" alt="Screenshot 2021-03-24 at 8 05 58 PM" src="https://user-images.githubusercontent.com/34631293/112403451-6f201780-8cdc-11eb-9650-899e6fbabff0.png">

