### PR TITLE
Removing `Name` from Wac templates

### DIFF
--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -316,7 +316,7 @@ coder envs create-from-config --name="dev-env" -f coder.yaml`,
 			if envName == "" {
 				return clog.Error("Must provide a environment name.",
 					clog.BlankLine,
-					clog.Tipf("Use --name=<env-name> to name your enviornment"),
+					clog.Tipf("Use --name=<env-name> to name your environment"),
 				)
 			}
 

--- a/internal/cmd/envs.go
+++ b/internal/cmd/envs.go
@@ -308,10 +308,17 @@ func createEnvFromRepoCmd() *cobra.Command {
 		Long:   "Create a new Coder environment from a config file.",
 		Hidden: true,
 		Example: `# create a new environment from git repository template
-coder envs create-from-config --name="dev-env" --repo-url github.com/cdr/m --branch my-branch
+coder envs create-from-config --name="dev-env" --repo-url github.com/cdr/m --ref my-branch
 coder envs create-from-config --name="dev-env" -f coder.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			if envName == "" {
+				return clog.Error("Must provide a environment name.",
+					clog.BlankLine,
+					clog.Tipf("Use --name=<env-name> to name your enviornment"),
+				)
+			}
 
 			client, err := newClient(ctx)
 			if err != nil {


### PR DESCRIPTION
## `--name` Flag

Add `--name` flag to `create-from-config`

```bash
coder envs create-from-config -r https://github.com/Emyrk/test --ref=master --name="wac-env" 
```

For https://github.com/cdr/m/pull/7619

## Repo validation from serverside error:

Also drop `repo url` validation, server now does it better: https://github.com/cdr/m/pull/7615 

```bash
error: Precondition Error : Status Code=412
  | The Git Repository URL should be using https://, the provided repository url "git@github.com:Emyrk/test" does not.
  | 
  | tip: Try using "https://github.com/Emyrk/test.git" instead

```