### PR TITLE
Fix `coder login` on Windows

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"net/url"
 	"strings"
 
@@ -73,7 +72,18 @@ func login(cmd *cobra.Command, envURL *url.URL) error {
 		fmt.Printf("Your browser has been opened to visit:\n\n\t%s\n\n", authURL.String())
 	}
 
-	token := readLine("Paste token here: ", cmd.InOrStdin())
+	fmt.Print("Paste token here: ")
+	var token string
+
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	scanner.Scan()
+
+	token = scanner.Text()
+
+	if err := scanner.Err(); err != nil {
+		return xerrors.Errorf("reading standard input: %w", err)
+	}
+
 	if err := pingAPI(cmd.Context(), envURL, token); err != nil {
 		return xerrors.Errorf("ping API with credentials: %w", err)
 	}
@@ -82,13 +92,6 @@ func login(cmd *cobra.Command, envURL *url.URL) error {
 	}
 	clog.LogSuccess("logged in")
 	return nil
-}
-
-func readLine(prompt string, r io.Reader) string {
-	reader := bufio.NewReader(r)
-	fmt.Print(prompt)
-	text, _ := reader.ReadString('\n')
-	return strings.TrimSuffix(text, "\n")
 }
 
 // pingAPI creates a client from the given url/token and try to exec an api call.

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -74,12 +74,9 @@ func login(cmd *cobra.Command, envURL *url.URL) error {
 
 	fmt.Print("Paste token here: ")
 	var token string
-
 	scanner := bufio.NewScanner(cmd.InOrStdin())
 	scanner.Scan()
-
 	token = scanner.Text()
-
 	if err := scanner.Err(); err != nil {
 		return xerrors.Errorf("reading standard input: %w", err)
 	}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -75,7 +75,7 @@ func login(cmd *cobra.Command, envURL *url.URL) error {
 	fmt.Print("Paste token here: ")
 	var token string
 	scanner := bufio.NewScanner(cmd.InOrStdin())
-	scanner.Scan()
+	_ = scanner.Scan()
 	token = scanner.Text()
 	if err := scanner.Err(); err != nil {
 		return xerrors.Errorf("reading standard input: %w", err)


### PR DESCRIPTION
See CH10090 https://app.clubhouse.io/coder/story/10090/coder-login-fails-windows-command-prompt-1-17-2

Switches to bufio.Scanner for reading the token. Thanks @jawnsy for the guidance

before: 
```sh
C:\Users\victo>coder login https://dev.coding.pics
Your browser has been opened to visit:

        https://dev.coding.pics/internal-auth?show_token=true

Paste token here: REDACTED
fatal: login error: ping API with credentials: call api: Execute request: "Get \"https://dev.coding.pics/api/v0/users/me\": net/http: invalid header field value \"REDACTED\\r\" for key Session-Token"


C:\Users\victo> coder version

coder version v1.17.2 go1.15.10 windows/386
```

Edit: tested on Windows 10 and OSX to confirm it worked