### PR TITLE
Custom stun

### DIFF
--- a/agent/server.go
+++ b/agent/server.go
@@ -60,6 +60,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		s.log.Info(ctx, "connected to coder. awaiting connection requests")
 
+		s.log.Info(context.Background(), "stun", slog.F("url", s.listenURL.Hostname() + ":3478"))
 		for {
 			st, err := session.AcceptStream()
 			if err != nil {

--- a/agent/server.go
+++ b/agent/server.go
@@ -59,6 +59,7 @@ func (s *Server) Run(ctx context.Context) error {
 			return fmt.Errorf("open: %w", err)
 		}
 		s.log.Info(ctx, "connected to coder. awaiting connection requests")
+
 		for {
 			st, err := session.AcceptStream()
 			if err != nil {
@@ -67,6 +68,7 @@ func (s *Server) Run(ctx context.Context) error {
 			stream := &stream{
 				logger: s.log.Named(fmt.Sprintf("stream %d", st.StreamID())),
 				stream: st,
+				stunServer: s.listenURL.Hostname(),
 			}
 			go stream.listen()
 		}

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -19,6 +19,7 @@ import (
 type stream struct {
 	stream *yamux.Stream
 	logger slog.Logger
+	stunServer string
 
 	rtc *webrtc.PeerConnection
 }
@@ -83,7 +84,7 @@ func (s *stream) processMessage(msg proto.Message) {
 	}
 
 	if msg.Offer != nil {
-		rtc, err := xwebrtc.NewPeerConnection()
+		rtc, err := xwebrtc.NewPeerConnection(s.stunServer + ":3478")
 		if err != nil {
 			s.fatal(fmt.Errorf("create connection: %w", err))
 			return

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -84,6 +84,7 @@ func (s *stream) processMessage(msg proto.Message) {
 	}
 
 	if msg.Offer != nil {
+		s.logger.Info(context.Background(), "stun", slog.F("url", s.stunServer + ":3478"))
 		rtc, err := xwebrtc.NewPeerConnection(s.stunServer + ":3478")
 		if err != nil {
 			s.fatal(fmt.Errorf("create connection: %w", err))

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -84,7 +84,6 @@ func (s *stream) processMessage(msg proto.Message) {
 	}
 
 	if msg.Offer != nil {
-		s.logger.Info(context.Background(), "stun", slog.F("url", s.stunServer + ":3478"))
 		rtc, err := xwebrtc.NewPeerConnection(s.stunServer + ":3478")
 		if err != nil {
 			s.fatal(fmt.Errorf("create connection: %w", err))

--- a/agent/stream.go
+++ b/agent/stream.go
@@ -50,6 +50,7 @@ func (s *stream) listen() {
 }
 
 func (s *stream) write(msg proto.Message) error {
+	s.logger.Info(context.Background(), "writing message", slog.F("msg", msg))
 	d, err := json.Marshal(&msg)
 	if err != nil {
 		return err

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -47,6 +47,7 @@ coder agent start --coder-url https://my-coder.com --token xxxx-xxxx
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			log := slog.Make(sloghuman.Sink(cmd.OutOrStdout()))
+			log.Leveled(slog.LevelDebug)
 
 			if coderURL == "" {
 				var ok bool

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -37,6 +37,7 @@ coder tunnel my-dev 3000 3000
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			log := slog.Make(sloghuman.Sink(os.Stderr))
+			log.Leveled(slog.LevelDebug)
 
 			remotePort, err := strconv.ParseUint(args[1], 10, 16)
 			if err != nil {

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -121,6 +121,8 @@ func (c *client) start() error {
 	if err != nil {
 		return fmt.Errorf("parse url: %w", err)
 	}
+
+	c.logger.Info(context.Background(), "stun", slog.F("url", stunURL.Hostname() + ":3478"))
 	rtc, err := xwebrtc.NewPeerConnection(stunURL.Hostname() + ":3478")
 	if err != nil {
 		return fmt.Errorf("create connection: %w", err)

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -122,7 +122,6 @@ func (c *client) start() error {
 		return fmt.Errorf("parse url: %w", err)
 	}
 
-	c.logger.Info(context.Background(), "stun", slog.F("url", stunURL.Hostname() + ":3478"))
 	rtc, err := xwebrtc.NewPeerConnection(stunURL.Hostname() + ":3478")
 	if err != nil {
 		return fmt.Errorf("create connection: %w", err)

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -11,7 +11,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				URLs: []string{"stun:stun.l.google.com:19302?transport=tcp"},
+				URLs: []string{"stun:stun.stunprotocol.org:3478?transport=tcp"},
 			},
 		},
 	})

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -11,7 +11,8 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				URLs: []string{"stun:" + stunServer},
+				//URLs: []string{"stun:" + stunServer},
+				URLs: []string{"stun:stun.l.google.com:19302"},
 			},
 		},
 	})

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -11,7 +11,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				URLs: []string{"stun:" + stunServer + "?transport=tcp"},
+				URLs: []string{"stun:stun.l.google.com:19302?transport=tcp"},
 			},
 		},
 	})

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -8,7 +8,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	se.DetachDataChannels()
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
 
-	stunServer = "stun:stun.stunprotocol.org?transport=tcp"
+	stunServer = "stun:stun.stunprotocol.org"
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -8,7 +8,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	se.DetachDataChannels()
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
 
-	stunServer = "stun:stun.stunprotocol.org"
+	stunServer = "stun:stun.stunprotocol.org:3478?transport=tcp"
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -11,7 +11,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				URLs: []string{"stun:" + stunServer + ":3478?transport=tcp"},
+				URLs: []string{"stun:" + stunServer + "?transport=tcp"},
 			},
 		},
 	})

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -3,8 +3,7 @@ package xwebrtc
 import "github.com/pion/webrtc/v3"
 
 // NewPeerConnection creates a new peer connection.
-// It uses the Google stun server by default.
-func NewPeerConnection() (*webrtc.PeerConnection, error) {
+func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	se := webrtc.SettingEngine{}
 	se.DetachDataChannels()
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
@@ -12,7 +11,7 @@ func NewPeerConnection() (*webrtc.PeerConnection, error) {
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				URLs: []string{"stun:stun.l.google.com:19302"},
+				URLs: []string{"stun:" + stunServer},
 			},
 		},
 	})

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -8,7 +8,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	se.DetachDataChannels()
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
 
-	stunServer = "stun:stun.stunprotocol.org:3478"
+	stunServer = "stun:stun.l.google.com:19302"
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -8,7 +8,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	se.DetachDataChannels()
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
 
-	stunServer = "stun:stun.stunprotocol.org:3478?transport=tcp"
+	stunServer = "stun:stun.stunprotocol.org:3478"
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -11,7 +11,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				URLs: []string{"stun:stun.stunprotocol.org:3478?transport=tcp"},
+				URLs: []string{"stun:" + stunServer + ":3478?transport=tcp"},
 			},
 		},
 	})

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -11,8 +11,7 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				//URLs: []string{"stun:" + stunServer},
-				URLs: []string{"stun:stun.l.google.com:19302"},
+				URLs: []string{"stun:" + stunServer + "?transport=tcp"},
 			},
 		},
 	})

--- a/internal/x/xwebrtc/conn.go
+++ b/internal/x/xwebrtc/conn.go
@@ -8,10 +8,11 @@ func NewPeerConnection(stunServer string) (*webrtc.PeerConnection, error) {
 	se.DetachDataChannels()
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
 
+	stunServer = "stun:stun.stunprotocol.org?transport=tcp"
 	return api.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				URLs: []string{"stun:" + stunServer + "?transport=tcp"},
+				URLs: []string{stunServer},
 			},
 		},
 	})


### PR DESCRIPTION
experimenting with running our own stun server in coder

1. deploy https://github.com/cdr/enterprise-helm/pull/55
2. make an env on the dev deployment
2. do coder login on 2 different machines
3. use ce-psql and run `select agent_token, name from environments;` get an env token and name
4. start the agent on machine 1 with `CODER_AGENT_TOKEN=606f6f5b-b9e6132f7c145a0af55c7352 go run cmd/coder/main.go agent start`
5. run the tunnel on a different machine with `go run cmd/coder/main.go tunnel test-4 8000 4000`

You can hardcode other stun servers and see it works, even with the tcp transport, so it's something with the stun server itself or the addresses it's resolving.

useful reading:
http://www.stunprotocol.org/

stun server help doc:
```
➜  coder-cli git:(custom-stun) docker run akiroz/stunserver:1.2.16
Unable to find image 'akiroz/stunserver:1.2.16' locally
1.2.16: Pulling from akiroz/stunserver
f08d8e2a3ba1: Pull complete 
3baa9cb2483b: Pull complete 
94e5ff4c0b15: Pull complete 
1860925334f9: Pull complete 
436bbff4fffc: Pull complete 
ee4241ce61d5: Pull complete 
c1748a0ea81c: Pull complete 
b0c56d166e4d: Pull complete 
Digest: sha256:5d826bd34afaac26d1b2238f9663b6123616ca96b79145c931984daae7c5a6e1
Status: Downloaded newer image for akiroz/stunserver:1.2.16
^C%                                                                                                                                                                       ➜  coder-cli git:(custom-stun) docker run akiroz/stunserver:1.2.16 --help
STUNSERVER(1) January 22, 2012 | User Manual



NAME


stunserver - STUN protocol service (RFCs: 3489, 5389, 5789, 5780)



SYNOPSIS


stunserver OPTIONS



DESCRIPTION


stunserver starts a STUN listening service that responds to STUN binding
requests from remote clients. Options are described below.



OPTIONS


The following options are supported.

    --mode MODE
    --primaryinterface INTERFACE
    --altinterface INTERFACE
    --primaryport PORTNUMBER
    --altport PORTNUMBER
    --family IPVERSION
    --protocol PROTO
    --maxconn MAXCONN
    --verbosity LOGLEVEL
    --ddp
    --primaryadvertised
    --altadvertised
    --configfile
    --help

Details of each option are as follows.

--mode MODE

Where the MODE parameter specified is either "basic" or "full". In basic mode,
the server listens on a single port. Basic mode is sufficient for basic NAT
traversal scenarios in which a client needs to discover its external IP
address and obtain a port mapping for a local port it is listening on. The
STUN CHANGE-REQUEST attribute is not supported in basic mode.

In full mode, the STUN service listens on two different interfaces and two
different ports on each. A client binding request may specify an option for
the server to send the response back from one of the alternate interfaces
and/or ports. Full mode facilitates clients attempting to discover NAT
behavior and NAT filtering behavior of the network they are on. Full mode
requires two unique IP addresses on the host. When run over TCP, the service
is not able to support a CHANGE-REQUEST attribute from the client.

If this parameter is not specified, basic mode is the default.

------------------------------------------------------------------------

--primaryinterface INTERFACE

Where INTERFACE specified is either a local IP address (e.g. "192.168.1.2") of
the host or the name of a network interface (e.g. "eth0").

The interface or address specified will be used by the service as the primary
listening address.

In basic mode, the default is to bind to all available adapters (INADDR_ANY).
In full mode, the default is to bind to the first non-localhost adapter with a
configured IP address.

------------------------------------------------------------------------

--altinterface INTERFACE

Where INTERFACE specified is either a local IP address (e.g. "192.168.1.3") of
the host or the name of a network interface (e.g. "eth1").

This parameter is nearly identical as the --primaryinterface option except
that it specifies the alternate listening address for full mode.

This option is ignored in basic mode. In full mode, the default is to bind to
the second non-localhost adapter with a configured IP address.

------------------------------------------------------------------------

--primaryport PORTNUM

Where PORTNUM is a value between 1 to 65535.

This is the primary port the server will bind to for listening for incoming
binding requests. The service will bind both the primary address and the
alternate address to this port.

The default is 3478.

------------------------------------------------------------------------

--altport PORTNUM

Where PORTNUM is a value between 1 to 65535.

This is the alternate port the server will bind to for listening for incoming
binding requests. The service will bind both the primary address and the
alternate address to this port.

This option is ignored in basic mode. The default is 3479.

------------------------------------------------------------------------

--family IPVERSION

Where IPVERSION is either "4" or "6" to specify the usage of IPV4 or IPV6.

The default family is 4 for IPv4 usage.

------------------------------------------------------------------------

--protocol PROTO

Where PROTO is either IP protocol, "udp" or "tcp".

udp is the default.

------------------------------------------------------------------------

--maxconn MAXCONN

Where MAXCONN is a value between 1 and 100000.

For TCP mode, this parameter specifies the maximum number of simultaneous
connections that can exist at any given time.

This parameter is ignored when the protocol is UDP. The default value is 1000

------------------------------------------------------------------------

--verbosity LOGLEVEL

Where LOGLEVEL is a value greater than or equal to 0.

This parameter specifies how much is printed to the console with regards to
initialization, errors, and network activity. A value of 0 specifies a very
minimal amount of output. A value of 1 shows slightly more. A value of 2 shows
even more. Specifying 3 will show a lot more.

The default is 0.

------------------------------------------------------------------------

--ddp

The --ddp switch is for "Distributed Denial (of service) Protection". Any
client IP address that floods the service with too many packets in a short
interval is put into a "penalty box" that will result in subsequent packets
received from this IP to be dropped. The result is that the client receives no
response.

------------------------------------------------------------------------

--primaryadvertised PRIMARY-IP

--altadvertised ALT-IP

Where PRIMARY-IP and ALT-IP are valid numeric IP address strings (e.g.
"101.23.45.67") that are the public IP addresses of the --primaryinterface and
--altinterface addresses discussed above.

These two parameters are for advanced usage only. It is intended for support
of running a STUN server in full mode on Amazon EC2 or other hosted
environment where the server is running behind a NAT. Do not set this
parameter unless you know specifically the effect it creates.

Normally, without these parameters being set, the ORIGIN attribute,
OTHER-ADDRESS attribute, and CHANGED-ADDRESS attributes are are determined by
querying the local adapters or sockets for the IP address they are listening
on. When running the server in a NAT environment, binding responses will still
contain a correct set of mapping address attributes, such that P2P
connectivity may succeed. However, the the ORIGIN, OTHER-ADDRESS, and
CHANGED-ADDRESS attributes sent by the server will be incorrect. The impact of
sending an incorrect OTHER-ADDRESS or CHANGED-ADDRESS will result in a client
attempting to do NAT Behavior tests or NAT filtering tests to report an
incorrect result.

For more details, visit www.stunprotocol.org for details on how to correctly
set these parameters for use within Amazon EC2.

------------------------------------------------------------------------

--configfile FILENAME

The --configfile switch allows the server to be configured with a JSON
configuration file rather that through command line parameters. If this switch
is specified, most other command line parameters will be ignored. (--verbosity
is the only one honored). Instead of configuring the server with command line
parameters, the configuration will be read from file. Since multiple
configurations can be specified, this has the added advantage of allowing
multiple protocols and IP families to run within the same process (each in a
separate thread). The fields of each configuration node are named identical to
the corresponding command line parameters (with the leading dashes removed).
An example stun.conf configuration file is shipped in the "testcode" folder of
the source package

------------------------------------------------------------------------

--reuseaddr

The --reuseaddr switch allows the STUN server port to be shared with other
processes. This is useful for scenarios where another process needs to send
from the STUN server port.

------------------------------------------------------------------------

--help

Prints this help page



EXAMPLES


stunserver
    With no options, starts a basic STUN binding service on UDP port 3478.

stunserver --mode full --primaryinterface 128.34.56.78 --altinterface
128.34.56.79

    Above example starts a dual-host STUN service on the the interfaces
    identified by the IP address "128.34.56.78" and "128.34.56.79". There are
    four UDP socket listeners

    128.34.56.78:3478 (Primary IP, Primary Port) 128.34.56.78:3479 (Primary
    IP, Alternate Port) 128.34.56.79:3478 (Primary IP, Primary Port)
    128.34.56.79:3479 (Alternate IP, Alternate Port)

An error occurs if the addresses specified do not exist on the local host
running the service.

stunserver --mode full --primaryinterface eth0 --altinterface eth1
    Same as above, except the interfaces are specified by their names as
    enumerated by the system. The "ifconfig" or "ipconfig" command will
    enumerate available interface names.



AUTHOR


john selbie (john@selbie.com)

```