### PR TITLE
Add coder providers rename command

### DIFF
--- a/coder-sdk/interface.go
+++ b/coder-sdk/interface.go
@@ -233,6 +233,6 @@ type Client interface {
 	// allowing it to continue creating new workspaces and provisioning resources for them.
 	UnCordonWorkspaceProvider(ctx context.Context, id string) error
 
-	// RenameWorkspaceProvider changes an existing cordoned providers name field.
+	// RenameWorkspaceProvider changes an existing providers name field.
 	RenameWorkspaceProvider(ctx context.Context, id string, name string) error
 }

--- a/coder-sdk/interface.go
+++ b/coder-sdk/interface.go
@@ -232,4 +232,7 @@ type Client interface {
 	// UnCordonWorkspaceProvider changes an existing cordoned providers status to 'Ready';
 	// allowing it to continue creating new workspaces and provisioning resources for them.
 	UnCordonWorkspaceProvider(ctx context.Context, id string) error
+
+	// RenameWorkspaceProvider changes an existing cordoned providers name field.
+	RenameWorkspaceProvider(ctx context.Context, id string, name string) error
 }

--- a/coder-sdk/workspace_providers.go
+++ b/coder-sdk/workspace_providers.go
@@ -123,3 +123,18 @@ func (c *DefaultClient) UnCordonWorkspaceProvider(ctx context.Context, id string
 	}
 	return nil
 }
+
+// RenameWorkspaceProviderReq defines the request parameters for changing a workspace provider name.
+type RenameWorkspaceProviderReq struct {
+	Name string `json:"name"`
+}
+
+// RenameWorkspaceProvider changes an existing cordoned providers name field.
+func (c *DefaultClient) RenameWorkspaceProvider(ctx context.Context, id string, name string) error {
+	req := RenameWorkspaceProviderReq{Name: name}
+	err := c.requestBody(ctx, http.MethodPatch, "/api/private/resource-pools/"+id, req, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This allows users to change the name of a workspace provider with `coder providers rename old-name new-name`