### PR TITLE
fix: Optional --name for urls create [ch8011]

### DIFF
--- a/coder-sdk/devurl.go
+++ b/coder-sdk/devurl.go
@@ -40,7 +40,7 @@ type CreateDevURLReq struct {
 	Scheme string `json:"scheme"`
 }
 
-// CreateDevURL inserts a new devurl for the authenticated user.
+// CreateDevURL inserts a new dev URL for the authenticated user.
 func (c *DefaultClient) CreateDevURL(ctx context.Context, envID string, req CreateDevURLReq) error {
 	return c.requestBody(ctx, http.MethodPost, "/api/v0/environments/"+envID+"/devurls", req, nil)
 }

--- a/docs/coder_urls.md
+++ b/docs/coder_urls.md
@@ -17,7 +17,7 @@ Interact with environment DevURLs
 ### SEE ALSO
 
 * [coder](coder.md)	 - coder provides a CLI for working with an existing Coder installation
-* [coder urls create](coder_urls_create.md)	 - Create a new devurl for an environment
+* [coder urls create](coder_urls_create.md)	 - Create a new dev URL for a workspace
 * [coder urls ls](coder_urls_ls.md)	 - List all DevURLs for an environment
 * [coder urls rm](coder_urls_rm.md)	 - Remove a dev url
 

--- a/docs/coder_urls_create.md
+++ b/docs/coder_urls_create.md
@@ -1,9 +1,15 @@
 ## coder urls create
 
-Create a new devurl for an environment
+Create a new dev URL for a workspace
 
 ```
-coder urls create [env_name] [port] [flags]
+coder urls create [workspace_name] [port] [flags]
+```
+
+### Examples
+
+```
+coder urls create my-workspace 8080 --name my-dev-url
 ```
 
 ### Options

--- a/internal/cmd/urls.go
+++ b/internal/cmd/urls.go
@@ -122,11 +122,11 @@ func createDevURLCmd() *cobra.Command {
 		scheme  string
 	)
 	cmd := &cobra.Command{
-		Use:     "create [env_name] [port]",
-		Short:   "Create a new devurl for an environment",
+		Use:     "create [workspace_name] [port]",
+		Short:   "Create a new dev URL for a workspace",
 		Aliases: []string{"edit"},
 		Args:    xcobra.ExactArgs(2),
-		// Run creates or updates a devURL
+		Example: `coder urls create my-workspace 8080 --name my-dev-url`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				envName = args[0]
@@ -195,8 +195,6 @@ func createDevURLCmd() *cobra.Command {
 	cmd.Flags().StringVar(&access, "access", "private", "Set DevURL access to [private | org | authed | public]")
 	cmd.Flags().StringVar(&urlname, "name", "", "DevURL name")
 	cmd.Flags().StringVar(&scheme, "scheme", "http", "Server scheme (http|https)")
-	_ = cmd.MarkFlagRequired("name")
-
 	return cmd
 }
 


### PR DESCRIPTION
## Demo

### Help

```console
$ go run ./cmd/coder/main.go  urls create --help
Create a new dev URL for a workspace

Usage:
  coder urls create [workspace_name] [port] [flags]

Aliases:
  create, edit

Examples:
coder urls create my-workspace 8080 --name my-dev-url

Flags:
      --access string   Set DevURL access to [private | org | authed | public] (default "private")
  -h, --help            help for create
      --name string     DevURL name
      --scheme string   Server scheme (http|https) (default "http")

Global Flags:
  -v, --verbose   show verbose output
```

### Create

```console
$ go run ./cmd/coder/main.go urls create grey-m-built-in 3001
success: created devurl for port 3001
```


### List

```console
URL                                                  Port    Access     Name     Scheme    
https://3001-grey-m-built-in-grey.<REST_IS_OBFUSCATED>/    3001    PRIVATE             http      
```