### PR TITLE
fix: Retry RTC connection attempts multiple times

### DIFF
--- a/wsnet/listen_test.go
+++ b/wsnet/listen_test.go
@@ -11,10 +11,13 @@ import (
 	"nhooyr.io/websocket"
 )
 
+func init() {
+	// We override this value to make tests faster.
+	connectionRetryInterval = 10 * time.Millisecond
+}
+
 func TestListen(t *testing.T) {
 	t.Run("Reconnect", func(t *testing.T) {
-		connectionRetryInterval = 10 * time.Millisecond
-
 		var (
 			connCh = make(chan *websocket.Conn)
 			mux    = http.NewServeMux()


### PR DESCRIPTION
We were checking if the dialer would retry once, which it always would.

This ensures the dialer retries infinitely, as long as:

- The context isn't expired.
- The first connection was successful.
