### PR TITLE
fix: Stop looping retries after dial failure

### DIFF
--- a/wsnet/listen.go
+++ b/wsnet/listen.go
@@ -49,6 +49,9 @@ func Listen(ctx context.Context, broker string) (io.Closer, error) {
 					case <-ctx.Done():
 						err = ctx.Err()
 					}
+					if err == nil {
+						break
+					}
 					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 						break
 					}

--- a/wsnet/listen.go
+++ b/wsnet/listen.go
@@ -49,10 +49,7 @@ func Listen(ctx context.Context, broker string) (io.Closer, error) {
 					case <-ctx.Done():
 						err = ctx.Err()
 					}
-					if err == nil {
-						break
-					}
-					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 						break
 					}
 				}


### PR DESCRIPTION
Pretty unfortunate bug here... noticed while testing.

After the initial dial the loop was never exited, causing infinite redials.