### PR TITLE
wsnet dial policy

### DIFF
--- a/wsnet/dial.go
+++ b/wsnet/dial.go
@@ -67,7 +67,7 @@ func Dial(conn net.Conn, iceServers []webrtc.ICEServer) (*Dialer, error) {
 		return nil, fmt.Errorf("set local offer: %w", err)
 	}
 
-	offerMessage, err := json.Marshal(&ProtoMessage{
+	offerMessage, err := json.Marshal(&BrokerMessage{
 		Offer:   &offer,
 		Servers: iceServers,
 	})
@@ -124,7 +124,7 @@ func (d *Dialer) negotiate() (err error) {
 	}()
 
 	for {
-		var msg ProtoMessage
+		var msg BrokerMessage
 		err = decoder.Decode(&msg)
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
 			break

--- a/wsnet/dial.go
+++ b/wsnet/dial.go
@@ -235,7 +235,6 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 				Net: res.Net,
 				Err: err,
 			}
-			return
 		}
 		errCh <- err
 	}()

--- a/wsnet/dial.go
+++ b/wsnet/dial.go
@@ -67,7 +67,7 @@ func Dial(conn net.Conn, iceServers []webrtc.ICEServer) (*Dialer, error) {
 		return nil, fmt.Errorf("set local offer: %w", err)
 	}
 
-	offerMessage, err := json.Marshal(&protoMessage{
+	offerMessage, err := json.Marshal(&ProtoMessage{
 		Offer:   &offer,
 		Servers: iceServers,
 	})
@@ -124,7 +124,7 @@ func (d *Dialer) negotiate() (err error) {
 	}()
 
 	for {
-		var msg protoMessage
+		var msg ProtoMessage
 		err = decoder.Decode(&msg)
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
 			break

--- a/wsnet/dial.go
+++ b/wsnet/dial.go
@@ -218,21 +218,21 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 
 	errCh := make(chan error)
 	go func() {
-		var init dialChannelMessage
-		err = json.NewDecoder(rw).Decode(&init)
+		var res DialChannelResponse
+		err = json.NewDecoder(rw).Decode(&res)
 		if err != nil {
-			errCh <- fmt.Errorf("read init: %w", err)
+			errCh <- fmt.Errorf("read dial response: %w", err)
 			return
 		}
-		if init.Err == "" {
+		if res.Err == "" {
 			close(errCh)
 			return
 		}
-		err := errors.New(init.Err)
-		if init.Net != "" {
-			errCh <- &net.OpError{
-				Op:  init.Op,
-				Net: init.Net,
+		err := errors.New(res.Err)
+		if res.Code == CodeDialErr {
+			err = &net.OpError{
+				Op:  res.Op,
+				Net: res.Net,
 				Err: err,
 			}
 			return

--- a/wsnet/listen.go
+++ b/wsnet/listen.go
@@ -17,16 +17,14 @@ import (
 	"cdr.dev/coder-cli/coder-sdk"
 )
 
-const OpNotPermittedByPolicy = "port_not_permitted"
-
-var connectionRetryInterval = time.Second
-
 // Codes for DialChannelResponse.
 const (
 	CodeDialErr       = "dial_error"
 	CodePermissionErr = "permission_error"
 	CodeBadAddressErr = "bad_address_error"
 )
+
+var connectionRetryInterval = time.Second
 
 // DialChannelResponse is used to notify a dial channel of a
 // listening state. Modeled after net.OpError, and marshalled

--- a/wsnet/proto.go
+++ b/wsnet/proto.go
@@ -107,15 +107,6 @@ func (msg BrokerMessage) getAddress(protocol string) (netwk, addr string, err er
 	return "", "", fmt.Errorf("connections are not permitted to %q by policy", protocol)
 }
 
-// dialChannelMessage is used to notify a dial channel of a
-// listening state. Modeled after net.OpError, and marshalled
-// to that if Net is not "".
-type dialChannelMessage struct {
-	Err string
-	Net string
-	Op  string
-}
-
 // canonicalizeHost converts all representations of "localhost" to "localhost".
 func canonicalizeHost(addr string) string {
 	addr = strings.TrimPrefix(addr, "[")

--- a/wsnet/proto.go
+++ b/wsnet/proto.go
@@ -131,3 +131,14 @@ func canonicalizeHost(addr string) string {
 	}
 	return addr
 }
+
+type notPermittedByPolicyErr struct {
+	protocol string
+}
+
+var _ error = notPermittedByPolicyErr{}
+
+// Error implements error.
+func (e notPermittedByPolicyErr) Error() string {
+	return fmt.Sprintf("connections are not permitted to %q by policy", e.protocol)
+}

--- a/wsnet/proto.go
+++ b/wsnet/proto.go
@@ -1,6 +1,12 @@
 package wsnet
 
 import (
+	"fmt"
+	"math/bits"
+	"net"
+	"strconv"
+	"strings"
+
 	"github.com/pion/webrtc/v3"
 )
 
@@ -9,14 +15,31 @@ import (
 type DialPolicy struct {
 	// If network is empty, it applies to all networks.
 	Network string `json:"network"`
-	// If host is empty, it applies to all hosts. "localhost" and any IP address
-	// under "127.0.0.0/8" can be used interchangeably.
+	// Host is the IP or hostname of the address. It should not contain the
+	// port.If empty, it applies to all hosts. "localhost", [::1], and any IPv4
+	// address under "127.0.0.0/8" can be used interchangeably.
 	Host string `json:"address"`
 	// If port is 0, it applies to all ports.
 	Port uint16 `json:"port"`
 }
 
-// ProtoMessage is used for brokering a dialer and listener.
+// permits checks if a DialPolicy permits a specific network + host + port
+// combination. The host must be put through normalizeHost first.
+func (p DialPolicy) permits(network, host string, port uint16) bool {
+	if p.Network != "" && p.Network != network {
+		return false
+	}
+	if p.Host != "" && canonicalizeHost(p.Host) != host {
+		return false
+	}
+	if p.Port != 0 && p.Port != port {
+		return false
+	}
+
+	return true
+}
+
+// BrokerMessage is used for brokering a dialer and listener.
 //
 // Dialers initiate an exchange by providing an Offer,
 // along with a list of ICE servers for the listener to
@@ -24,7 +47,7 @@ type DialPolicy struct {
 //
 // The listener should respond with an offer, then both
 // sides can begin exchanging candidates.
-type ProtoMessage struct {
+type BrokerMessage struct {
 	// Dialer -> Listener
 	Offer   *webrtc.SessionDescription `json:"offer"`
 	Servers []webrtc.ICEServer         `json:"servers"`
@@ -40,6 +63,50 @@ type ProtoMessage struct {
 	Candidate string `json:"candidate"`
 }
 
+// getAddress parses the data channel's protocol into an address suitable for
+// net.Dial. It also verifies that the BrokerMessage permits connecting to said
+// address.
+func (msg BrokerMessage) getAddress(protocol string) (netwk, addr string, err error) {
+	parts := strings.SplitN(protocol, ":", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid dial address: %v", protocol)
+	}
+	host, port, err := net.SplitHostPort(parts[1])
+	if err != nil {
+		return "", "", fmt.Errorf("invalid dial address: %v", protocol)
+	}
+
+	var (
+		network    = parts[0]
+		normalHost = canonicalizeHost(host)
+		// Still return the original host value, not the canonical value.
+		fullAddr = net.JoinHostPort(host, port)
+	)
+	if network == "" {
+		return "", "", fmt.Errorf("invalid dial address %q network: %v", protocol, network)
+	}
+	if host == "" {
+		return "", "", fmt.Errorf("invalid dial address %q host: %v", protocol, host)
+	}
+
+	portParsed, err := strconv.Atoi(port)
+	if err != nil || portParsed < 0 || bits.Len(uint(portParsed)) > 16 {
+		return "", "", fmt.Errorf("invalid dial address %q port: %v", protocol, port)
+	}
+	if len(msg.Policies) == 0 {
+		return network, fullAddr, nil
+	}
+
+	portParsedU16 := uint16(portParsed)
+	for _, p := range msg.Policies {
+		if p.permits(network, normalHost, portParsedU16) {
+			return network, fullAddr, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("connections are not permitted to %q by policy", protocol)
+}
+
 // dialChannelMessage is used to notify a dial channel of a
 // listening state. Modeled after net.OpError, and marshalled
 // to that if Net is not "".
@@ -47,4 +114,20 @@ type dialChannelMessage struct {
 	Err string
 	Net string
 	Op  string
+}
+
+// canonicalizeHost converts all representations of "localhost" to "localhost".
+func canonicalizeHost(addr string) string {
+	addr = strings.TrimPrefix(addr, "[")
+	addr = strings.TrimSuffix(addr, "]")
+
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return addr
+	}
+
+	if ip.IsLoopback() {
+		return "localhost"
+	}
+	return addr
 }

--- a/wsnet/proto.go
+++ b/wsnet/proto.go
@@ -4,7 +4,19 @@ import (
 	"github.com/pion/webrtc/v3"
 )
 
-// protoMessage is used for brokering a dialer and listener.
+// DialPolicy a single network + address + port combinations that a connection
+// is permitted to use.
+type DialPolicy struct {
+	// If network is empty, it applies to all networks.
+	Network string `json:"network"`
+	// If host is empty, it applies to all hosts. "localhost" and any IP address
+	// under "127.0.0.0/8" can be used interchangeably.
+	Host string `json:"address"`
+	// If port is 0, it applies to all ports.
+	Port uint16 `json:"port"`
+}
+
+// ProtoMessage is used for brokering a dialer and listener.
 //
 // Dialers initiate an exchange by providing an Offer,
 // along with a list of ICE servers for the listener to
@@ -12,10 +24,13 @@ import (
 //
 // The listener should respond with an offer, then both
 // sides can begin exchanging candidates.
-type protoMessage struct {
+type ProtoMessage struct {
 	// Dialer -> Listener
 	Offer   *webrtc.SessionDescription `json:"offer"`
 	Servers []webrtc.ICEServer         `json:"servers"`
+	// Policies denote which addresses the client can dial. If empty or nil, all
+	// addresses are permitted.
+	Policies []DialPolicy `json:"ports"`
 
 	// Listener -> Dialer
 	Error  string                     `json:"error"`

--- a/wsnet/proto_test.go
+++ b/wsnet/proto_test.go
@@ -1,0 +1,235 @@
+package wsnet
+
+import (
+	"fmt"
+	"testing"
+
+	"cdr.dev/slog/sloggers/slogtest/assert"
+)
+
+func Test_BrokerMessage(t *testing.T) {
+	t.Run("getAddress", func(t *testing.T) {
+		t.Run("OK", func(t *testing.T) {
+			var (
+				msg = BrokerMessage{
+					Policies: nil,
+				}
+				network = "tcp"
+				addr    = "localhost:1234"
+			)
+
+			protocol := formatAddress(network, addr)
+			gotNetwork, gotAddr, err := msg.getAddress(protocol)
+			assert.Success(t, "got address", err)
+			assert.Equal(t, "networks equal", network, gotNetwork)
+			assert.Equal(t, "addresses equal", addr, gotAddr)
+
+			msg.Policies = []DialPolicy{}
+			gotNetwork, gotAddr, err = msg.getAddress(protocol)
+			assert.Success(t, "got address", err)
+			assert.Equal(t, "networks equal", network, gotNetwork)
+			assert.Equal(t, "addresses equal", addr, gotAddr)
+		})
+
+		t.Run("InvalidProtocol", func(t *testing.T) {
+			cases := []struct {
+				protocol    string
+				errContains string
+			}{
+				{
+					protocol:    "",
+					errContains: "invalid",
+				},
+				{
+					protocol:    "a:b",
+					errContains: "invalid",
+				},
+				{
+					protocol:    "a:b:c:d",
+					errContains: "invalid",
+				},
+				{
+					protocol:    ":localhost:1234",
+					errContains: "network",
+				},
+				{
+					protocol:    "tcp::1234",
+					errContains: "host",
+				},
+				{
+					protocol:    "tcp:localhost:",
+					errContains: "port",
+				},
+				{
+					protocol:    "tcp:localhost:asdf",
+					errContains: "port",
+				},
+				{
+					protocol:    "tcp:localhost:-1",
+					errContains: "port",
+				},
+				{
+					// Overflow uint16.
+					protocol:    fmt.Sprintf("tcp:localhost:%v", uint(1)<<16),
+					errContains: "port",
+				},
+			}
+
+			var msg BrokerMessage
+			for i, c := range cases {
+				amsg := fmt.Sprintf("case %v %q: ", i, c)
+				gotNetwork, gotAddr, err := msg.getAddress(c.protocol)
+				assert.Error(t, amsg+"successfully got invalid address", err)
+				assert.ErrorContains(t, fmt.Sprintf("%verr contains %q", amsg, c.errContains), err, c.errContains)
+				assert.Equal(t, amsg+"empty network", "", gotNetwork)
+				assert.Equal(t, amsg+"empty address", "", gotAddr)
+			}
+		})
+
+		t.Run("ChecksPolicies", func(t *testing.T) {
+			// ok == true tests automatically have a bunch of non-matching dial
+			// policies injected in front of them.
+			cases := []struct {
+				network string
+				host    string
+				port    uint16
+				policy  DialPolicy
+				ok      bool
+			}{
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("tcp", "localhost", 1234),
+					ok:      true,
+				},
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("udp", "example.com", 51),
+					ok:      false,
+				},
+				// Network checks.
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("", "localhost", 1234),
+					ok:      true,
+				},
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("udp", "localhost", 1234),
+					ok:      false,
+				},
+				// Host checks.
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("tcp", "", 1234),
+					ok:      true,
+				},
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("tcp", "127.0.0.1", 1234),
+					ok:      true,
+				},
+				{
+					network: "tcp",
+					host:    "127.0.0.1",
+					port:    1234,
+					policy:  dialPolicy("tcp", "127.1.2.3", 1234),
+					ok:      true,
+				},
+				{
+					network: "tcp",
+					host:    "[::1]",
+					port:    1234,
+					policy:  dialPolicy("tcp", "127.1.2.3", 1234),
+					ok:      true,
+				},
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("tcp", "example.com", 1234),
+					ok:      false,
+				},
+				{
+					network: "tcp",
+					host:    "example.com",
+					port:    1234,
+					policy:  dialPolicy("tcp", "localhost", 1234),
+					ok:      false,
+				},
+				// Port checks.
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("tcp", "localhost", 5678),
+					ok:      false,
+				},
+				{
+					network: "tcp",
+					host:    "localhost",
+					port:    1234,
+					policy:  dialPolicy("tcp", "localhost", 0),
+					ok:      true,
+				},
+			}
+
+			for i, c := range cases {
+				var (
+					amsg = fmt.Sprintf("case %v '%+v': ", i, c)
+					msg  = BrokerMessage{
+						Policies: []DialPolicy{c.policy},
+					}
+				)
+
+				// Add nonsense policies before the matching policy.
+				if c.ok {
+					msg.Policies = []DialPolicy{
+						dialPolicy("asdf", "localhost", 1234),
+						dialPolicy("tcp", "asdf", 1234),
+						dialPolicy("tcp", "localhost", 17208),
+						c.policy,
+					}
+				}
+
+				// Test DialPolicy.
+				assert.Equal(t, amsg+"policy matches", c.ok, c.policy.permits(c.network, canonicalizeHost(c.host), c.port))
+
+				// Test BrokerMessage.
+				protocol := formatAddress(c.network, fmt.Sprintf("%v:%v", c.host, c.port))
+				gotNetwork, gotAddr, err := msg.getAddress(protocol)
+				if c.ok {
+					assert.Success(t, amsg, err)
+				} else {
+					assert.Error(t, amsg+"successfully got invalid address", err)
+					assert.ErrorContains(t, amsg+"err contains 'not permitted'", err, "not permitted")
+					assert.Equal(t, amsg+"empty network", "", gotNetwork)
+					assert.Equal(t, amsg+"empty address", "", gotAddr)
+				}
+			}
+		})
+	})
+}
+
+func formatAddress(network, addr string) string {
+	return fmt.Sprintf("%v:%v", network, addr)
+}
+
+func dialPolicy(network, host string, port uint16) DialPolicy {
+	return DialPolicy{
+		Network: network,
+		Host:    host,
+		Port:    port,
+	}
+}

--- a/wsnet/rtc.go
+++ b/wsnet/rtc.go
@@ -186,7 +186,7 @@ func proxyICECandidates(conn *webrtc.PeerConnection, w io.Writer) func() {
 		queue   = []*webrtc.ICECandidate{}
 		flushed = false
 		write   = func(i *webrtc.ICECandidate) {
-			b, _ := json.Marshal(&protoMessage{
+			b, _ := json.Marshal(&ProtoMessage{
 				Candidate: i.ToJSON().Candidate,
 			})
 			_, _ = w.Write(b)

--- a/wsnet/rtc.go
+++ b/wsnet/rtc.go
@@ -186,7 +186,7 @@ func proxyICECandidates(conn *webrtc.PeerConnection, w io.Writer) func() {
 		queue   = []*webrtc.ICECandidate{}
 		flushed = false
 		write   = func(i *webrtc.ICECandidate) {
-			b, _ := json.Marshal(&ProtoMessage{
+			b, _ := json.Marshal(&BrokerMessage{
 				Candidate: i.ToJSON().Candidate,
 			})
 			_, _ = w.Write(b)


### PR DESCRIPTION
Adds `Policies` field to `ProtoMessage` which denotes which network + host + port combinations a client connection may use. Makes `ProtoMessage` public.