### PR TITLE
feat: Add Benchmarks to test WebRTC connections

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,45 @@ jobs:
         with:
           args: make -j test/coverage
 
+  bench:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - uses: actions/cache@v2
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-go-bench
+          restore-keys: |
+            ${{ runner.os }}-go-bench-
+
+      - name: bench
+        uses: ./ci/image
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODER_URL: ${{ secrets.CODER_URL }}
+          CODER_EMAIL: ${{ secrets.CODER_EMAIL }}
+          CODER_PASSWORD: ${{ secrets.CODER_PASSWORD }}
+        with:
+          args: sh -c 'go test -bench=. cdr.dev/coder-cli/wsnet | tee output.txt'
+
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          tool: 'go'
+          output-file-path: output.txt
+          external-data-json-path: ./cache/benchmark-data.json
+          fail-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-alert: true
+
   gendocs:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,45 +54,6 @@ jobs:
         with:
           args: make -j test/coverage
 
-  bench:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - uses: actions/cache@v2
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-go-bench
-          restore-keys: |
-            ${{ runner.os }}-go-bench-
-
-      - name: bench
-        uses: ./ci/image
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODER_URL: ${{ secrets.CODER_URL }}
-          CODER_EMAIL: ${{ secrets.CODER_EMAIL }}
-          CODER_PASSWORD: ${{ secrets.CODER_PASSWORD }}
-        with:
-          args: sh -c "go test -bench=. cdr.dev/coder-cli/wsnet | tee output.txt"
-
-      - name: Store benchmark result
-        uses: rhysd/github-action-benchmark@v1
-        with:
-          tool: 'go'
-          output-file-path: output.txt
-          external-data-json-path: ./cache/benchmark-data.json
-          fail-on-alert: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
-
   gendocs:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,7 +81,7 @@ jobs:
           CODER_EMAIL: ${{ secrets.CODER_EMAIL }}
           CODER_PASSWORD: ${{ secrets.CODER_PASSWORD }}
         with:
-          args: sh -c 'go test -bench=. cdr.dev/coder-cli/wsnet | tee output.txt'
+          args: sh -c "go test -bench=. cdr.dev/coder-cli/wsnet | tee output.txt"
 
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pion/datachannel v1.4.21
 	github.com/pion/dtls/v2 v2.0.9
 	github.com/pion/ice/v2 v2.1.7
+	github.com/pion/logging v0.2.2
 	github.com/pion/turn/v2 v2.0.5
 	github.com/pion/webrtc/v3 v3.0.29
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4

--- a/wsnet/conn.go
+++ b/wsnet/conn.go
@@ -91,8 +91,13 @@ func (c *conn) Write(b []byte) (n int, err error) {
 	if c.dc.BufferedAmount()+uint64(len(b)) >= maxBufferedAmount {
 		<-c.sendMore
 	}
-	// Uncomment this line for it to work.
-	// time.Sleep(time.Microsecond)
+	// TODO (@kyle): There's an obvious race-condition here.
+	// This is an edge-case, as most-frequently data won't
+	// be pooled so synchronously, but is definitely possible.
+	//
+	// See: https://github.com/pion/sctp/issues/181
+	time.Sleep(time.Microsecond)
+
 	return c.rw.Write(b)
 }
 

--- a/wsnet/dial.go
+++ b/wsnet/dial.go
@@ -249,11 +249,14 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 		return nil, ctx.Err()
 	}
 
-	return &conn{
+	c := &conn{
 		addr: &net.UnixAddr{
 			Name: address,
 			Net:  network,
 		},
+		dc: dc,
 		rw: rw,
-	}, nil
+	}
+	c.init()
+	return c, nil
 }

--- a/wsnet/dial_test.go
+++ b/wsnet/dial_test.go
@@ -165,14 +165,14 @@ func TestDial(t *testing.T) {
 
 func BenchmarkThroughput(b *testing.B) {
 	sizes := []int64{
-		// 4,
-		// 16,
+		4,
+		16,
 		128,
-		// 256,
-		// 1024,
-		// 4096,
-		// 16384,
-		// 32768,
+		256,
+		1024,
+		4096,
+		16384,
+		32768,
 	}
 
 	listener, err := net.Listen("tcp", "0.0.0.0:0")

--- a/wsnet/dial_test.go
+++ b/wsnet/dial_test.go
@@ -167,11 +167,12 @@ func BenchmarkThroughput(b *testing.B) {
 	sizes := []int64{
 		// 4,
 		// 16,
+		128,
 		// 256,
 		// 1024,
 		// 4096,
 		// 16384,
-		32768,
+		// 32768,
 	}
 
 	listener, err := net.Listen("tcp", "0.0.0.0:0")

--- a/wsnet/dial_test.go
+++ b/wsnet/dial_test.go
@@ -3,9 +3,11 @@ package wsnet
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"errors"
 	"io"
 	"net"
+	"strconv"
 	"testing"
 
 	"github.com/pion/webrtc/v3"
@@ -159,4 +161,70 @@ func TestDial(t *testing.T) {
 			return
 		}
 	})
+}
+
+func BenchmarkThroughput(b *testing.B) {
+	sizes := []int64{
+		// 4,
+		// 16,
+		// 256,
+		// 1024,
+		// 4096,
+		// 16384,
+		32768,
+	}
+
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				b.Error(err)
+				return
+			}
+			go func() {
+				_, _ = io.Copy(io.Discard, conn)
+			}()
+		}
+	}()
+	connectAddr, listenAddr := createDumbBroker(b)
+	_, err = Listen(context.Background(), listenAddr)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+
+	dialer, err := DialWebsocket(context.Background(), connectAddr, nil)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	for _, size := range sizes {
+		size := size
+		bytes := make([]byte, size)
+		_, _ = rand.Read(bytes)
+		b.Run("Rand"+strconv.Itoa(int(size)), func(b *testing.B) {
+			b.SetBytes(size)
+			b.ReportAllocs()
+
+			conn, err := dialer.DialContext(context.Background(), listener.Addr().Network(), listener.Addr().String())
+			if err != nil {
+				b.Error(err)
+				return
+			}
+			defer conn.Close()
+
+			for i := 0; i < b.N; i++ {
+				_, err := conn.Write(bytes)
+				if err != nil {
+					b.Error(err)
+					break
+				}
+			}
+		})
+	}
 }

--- a/wsnet/listen.go
+++ b/wsnet/listen.go
@@ -326,36 +326,12 @@ func (l *listener) handle(msg BrokerMessage) func(dc *webrtc.DataChannel) {
 			}
 			defer conn.Close()
 			defer dc.Close()
+			defer rw.Close()
 
 			go func() {
 				_, _ = io.Copy(rw, conn)
 			}()
 			_, _ = io.Copy(conn, rw)
-
-			// bufs := make(chan []byte, 32)
-			// go func() {
-			// 	defer close(bufs)
-
-			// 	for {
-			// 		buf := <-bufs
-			// 		_, _ = conn.Write(buf)
-			// 	}
-			// }()
-
-			// buf := make([]byte, maxMessageLength)
-			// for {
-			// 	nr, err := rw.Read(buf)
-			// 	if nr > 0 {
-			// 		select {
-			// 		case bufs <- buf[0:nr]:
-			// 		default:
-			// 		}
-
-			// 	}
-			// 	if err != nil {
-			// 		break
-			// 	}
-			// }
 		})
 	}
 }

--- a/wsnet/listen.go
+++ b/wsnet/listen.go
@@ -331,6 +331,31 @@ func (l *listener) handle(msg BrokerMessage) func(dc *webrtc.DataChannel) {
 				_, _ = io.Copy(rw, conn)
 			}()
 			_, _ = io.Copy(conn, rw)
+
+			// bufs := make(chan []byte, 32)
+			// go func() {
+			// 	defer close(bufs)
+
+			// 	for {
+			// 		buf := <-bufs
+			// 		_, _ = conn.Write(buf)
+			// 	}
+			// }()
+
+			// buf := make([]byte, maxMessageLength)
+			// for {
+			// 	nr, err := rw.Read(buf)
+			// 	if nr > 0 {
+			// 		select {
+			// 		case bufs <- buf[0:nr]:
+			// 		default:
+			// 		}
+
+			// 	}
+			// 	if err != nil {
+			// 		break
+			// 	}
+			// }
 		})
 	}
 }

--- a/wsnet/rtc.go
+++ b/wsnet/rtc.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pion/dtls/v2"
 	"github.com/pion/ice/v2"
+	"github.com/pion/logging"
 	"github.com/pion/turn/v2"
 	"github.com/pion/webrtc/v3"
 )
@@ -159,6 +160,9 @@ func newPeerConnection(servers []webrtc.ICEServer) (*webrtc.PeerConnection, erro
 	se.SetSrflxAcceptanceMinWait(0)
 	se.DetachDataChannels()
 	se.SetICETimeouts(time.Second*5, time.Second*5, time.Second*2)
+	lf := logging.NewDefaultLoggerFactory()
+	lf.DefaultLogLevel = logging.LogLevelDebug
+	se.LoggerFactory = lf
 
 	// If one server is provided and we know it's TURN, we can set the
 	// relay acceptable so the connection starts immediately.

--- a/wsnet/rtc.go
+++ b/wsnet/rtc.go
@@ -161,7 +161,7 @@ func newPeerConnection(servers []webrtc.ICEServer) (*webrtc.PeerConnection, erro
 	se.DetachDataChannels()
 	se.SetICETimeouts(time.Second*5, time.Second*5, time.Second*2)
 	lf := logging.NewDefaultLoggerFactory()
-	lf.DefaultLogLevel = logging.LogLevelDebug
+	lf.DefaultLogLevel = logging.LogLevelDisabled
 	se.LoggerFactory = lf
 
 	// If one server is provided and we know it's TURN, we can set the

--- a/wsnet/wsnet_test.go
+++ b/wsnet/wsnet_test.go
@@ -26,7 +26,7 @@ import (
 
 // createDumbBroker proxies sockets between /listen and /connect
 // to emulate an authenticated WebSocket pair.
-func createDumbBroker(t *testing.T) (connectAddr string, listenAddr string) {
+func createDumbBroker(t testing.TB) (connectAddr string, listenAddr string) {
 	listener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		t.Error(err)

--- a/wsnet/wsnet_test.go
+++ b/wsnet/wsnet_test.go
@@ -20,6 +20,7 @@ import (
 	"cdr.dev/slog/sloggers/slogtest/assert"
 	"github.com/hashicorp/yamux"
 	"github.com/pion/ice/v2"
+	"github.com/pion/logging"
 	"github.com/pion/turn/v2"
 	"nhooyr.io/websocket"
 )
@@ -128,6 +129,8 @@ func createTURNServer(t *testing.T, server ice.SchemeType, pass string) string {
 		}}
 	}
 
+	lf := logging.NewDefaultLoggerFactory()
+	lf.DefaultLogLevel = logging.LogLevelDisabled
 	srv, err := turn.NewServer(turn.ServerConfig{
 		PacketConnConfigs: pcListeners,
 		ListenerConfigs:   listeners,
@@ -135,6 +138,7 @@ func createTURNServer(t *testing.T, server ice.SchemeType, pass string) string {
 		AuthHandler: func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
 			return turn.GenerateAuthKey(username, realm, pass), true
 		},
+		LoggerFactory: lf,
 	})
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Passes random sizes of byte slices through the connection to ensure buffering works as expected.

```bash
rem ~/P/c/coder-cli (rtcbench) go test -bench 'BenchmarkThroughput' cdr.dev/coder-cli/wsnet
goos: linux
goarch: amd64
pkg: cdr.dev/coder-cli/wsnet
cpu: Intel(R) Xeon(R) CPU
BenchmarkThroughput/Rand4-32               59210             19854 ns/op           0.20 MB/s        3002 B/op         88 allocs/op
BenchmarkThroughput/Rand16-32              58438             20366 ns/op           0.79 MB/s        3161 B/op         88 allocs/op
BenchmarkThroughput/Rand128-32             47649             23671 ns/op           5.41 MB/s        4817 B/op         89 allocs/op
BenchmarkThroughput/Rand256-32             48429             24614 ns/op          10.40 MB/s        6834 B/op         91 allocs/op
BenchmarkThroughput/Rand1024-32            44595             29377 ns/op          34.86 MB/s       19154 B/op        119 allocs/op
BenchmarkThroughput/Rand4096-32            10281            145791 ns/op          28.09 MB/s       73611 B/op        438 allocs/op
BenchmarkThroughput/Rand16384-32            6200            389575 ns/op          42.06 MB/s      281518 B/op       1471 allocs/op
BenchmarkThroughput/Rand32768-32            1746            911948 ns/op          35.93 MB/s      560390 B/op       2912 allocs/op
PASS
ok      cdr.dev/coder-cli/wsnet 13.915s
```