### PR TITLE
Dial logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for Coder CLI 
+# Makefile for Coder CLI
 
 .PHONY: clean build build/macos build/windows build/linux fmt lint gendocs test/go dev
 

--- a/wsnet/dial_test.go
+++ b/wsnet/dial_test.go
@@ -66,13 +66,16 @@ func TestDial(t *testing.T) {
 
 	t.Run("Ping", func(t *testing.T) {
 		t.Parallel()
+		log := slogtest.Make(t, nil)
 
 		connectAddr, listenAddr := createDumbBroker(t)
-		l, err := Listen(context.Background(), slogtest.Make(t, nil), listenAddr, "")
+		l, err := Listen(context.Background(), log, listenAddr, "")
 		require.NoError(t, err)
 		defer l.Close()
 
-		dialer, err := DialWebsocket(context.Background(), connectAddr, nil, nil)
+		dialer, err := DialWebsocket(context.Background(), connectAddr, &DialOptions{
+			Log: &log,
+		}, nil)
 		require.NoError(t, err)
 
 		err = dialer.Ping(context.Background())
@@ -81,14 +84,16 @@ func TestDial(t *testing.T) {
 
 	t.Run("Ping Close", func(t *testing.T) {
 		t.Parallel()
+		log := slogtest.Make(t, nil)
 
 		connectAddr, listenAddr := createDumbBroker(t)
-		l, err := Listen(context.Background(), slogtest.Make(t, nil), listenAddr, "")
+		l, err := Listen(context.Background(), log, listenAddr, "")
 		require.NoError(t, err)
 		defer l.Close()
 
 		turnAddr, closeTurn := createTURNServer(t, ice.SchemeTypeTURN)
 		dialer, err := DialWebsocket(context.Background(), connectAddr, &DialOptions{
+			Log: &log,
 			ICEServers: []webrtc.ICEServer{{
 				URLs:           []string{fmt.Sprintf("turn:%s", turnAddr)},
 				Username:       "example",
@@ -101,18 +106,22 @@ func TestDial(t *testing.T) {
 		_ = dialer.Ping(context.Background())
 		closeTurn()
 		err = dialer.Ping(context.Background())
+		assert.Error(t, err)
 		assert.ErrorIs(t, err, io.EOF)
 	})
 
 	t.Run("OPError", func(t *testing.T) {
 		t.Parallel()
+		log := slogtest.Make(t, nil)
 
 		connectAddr, listenAddr := createDumbBroker(t)
-		l, err := Listen(context.Background(), slogtest.Make(t, nil), listenAddr, "")
+		l, err := Listen(context.Background(), log, listenAddr, "")
 		require.NoError(t, err)
 		defer l.Close()
 
-		dialer, err := DialWebsocket(context.Background(), connectAddr, nil, nil)
+		dialer, err := DialWebsocket(context.Background(), connectAddr, &DialOptions{
+			Log: &log,
+		}, nil)
 		require.NoError(t, err)
 
 		_, err = dialer.DialContext(context.Background(), "tcp", "localhost:100")
@@ -125,6 +134,7 @@ func TestDial(t *testing.T) {
 
 	t.Run("Proxy", func(t *testing.T) {
 		t.Parallel()
+		log := slogtest.Make(t, nil)
 
 		listener, err := net.Listen("tcp", "0.0.0.0:0")
 		require.NoError(t, err)
@@ -138,11 +148,13 @@ func TestDial(t *testing.T) {
 		}()
 
 		connectAddr, listenAddr := createDumbBroker(t)
-		l, err := Listen(context.Background(), slogtest.Make(t, nil), listenAddr, "")
+		l, err := Listen(context.Background(), log, listenAddr, "")
 		require.NoError(t, err)
 		defer l.Close()
 
-		dialer, err := DialWebsocket(context.Background(), connectAddr, nil, nil)
+		dialer, err := DialWebsocket(context.Background(), connectAddr, &DialOptions{
+			Log: &log,
+		}, nil)
 		require.NoError(t, err)
 
 		conn, err := dialer.DialContext(context.Background(), listener.Addr().Network(), listener.Addr().String())
@@ -158,6 +170,7 @@ func TestDial(t *testing.T) {
 	// Expect that we'd get an EOF on the server closing.
 	t.Run("EOF on Close", func(t *testing.T) {
 		t.Parallel()
+		log := slogtest.Make(t, nil)
 
 		listener, err := net.Listen("tcp", "0.0.0.0:0")
 		require.NoError(t, err)
@@ -166,11 +179,13 @@ func TestDial(t *testing.T) {
 		}()
 
 		connectAddr, listenAddr := createDumbBroker(t)
-		l, err := Listen(context.Background(), slogtest.Make(t, nil), listenAddr, "")
+		l, err := Listen(context.Background(), log, listenAddr, "")
 		require.NoError(t, err)
 		defer l.Close()
 
-		dialer, err := DialWebsocket(context.Background(), connectAddr, nil, nil)
+		dialer, err := DialWebsocket(context.Background(), connectAddr, &DialOptions{
+			Log: &log,
+		}, nil)
 		require.NoError(t, err)
 
 		conn, err := dialer.DialContext(context.Background(), listener.Addr().Network(), listener.Addr().String())
@@ -184,13 +199,16 @@ func TestDial(t *testing.T) {
 
 	t.Run("Disconnect", func(t *testing.T) {
 		t.Parallel()
+		log := slogtest.Make(t, nil)
 
 		connectAddr, listenAddr := createDumbBroker(t)
-		l, err := Listen(context.Background(), slogtest.Make(t, nil), listenAddr, "")
+		l, err := Listen(context.Background(), log, listenAddr, "")
 		require.NoError(t, err)
 		defer l.Close()
 
-		dialer, err := DialWebsocket(context.Background(), connectAddr, nil, nil)
+		dialer, err := DialWebsocket(context.Background(), connectAddr, &DialOptions{
+			Log: &log,
+		}, nil)
 		require.NoError(t, err)
 
 		err = dialer.Close()
@@ -202,6 +220,7 @@ func TestDial(t *testing.T) {
 
 	t.Run("Disconnect DialContext", func(t *testing.T) {
 		t.Parallel()
+		log := slogtest.Make(t, nil)
 
 		tcpListener, err := net.Listen("tcp", "0.0.0.0:0")
 		require.NoError(t, err)
@@ -210,12 +229,13 @@ func TestDial(t *testing.T) {
 		}()
 
 		connectAddr, listenAddr := createDumbBroker(t)
-		l, err := Listen(context.Background(), slogtest.Make(t, nil), listenAddr, "")
+		l, err := Listen(context.Background(), log, listenAddr, "")
 		require.NoError(t, err)
 		defer l.Close()
 
 		turnAddr, closeTurn := createTURNServer(t, ice.SchemeTypeTURN)
 		dialer, err := DialWebsocket(context.Background(), connectAddr, &DialOptions{
+			Log: &log,
 			ICEServers: []webrtc.ICEServer{{
 				URLs:           []string{fmt.Sprintf("turn:%s", turnAddr)},
 				Username:       "example",
@@ -237,6 +257,7 @@ func TestDial(t *testing.T) {
 
 	t.Run("Active Connections", func(t *testing.T) {
 		t.Parallel()
+		log := slogtest.Make(t, nil)
 
 		listener, err := net.Listen("tcp", "0.0.0.0:0")
 		if err != nil {
@@ -252,7 +273,10 @@ func TestDial(t *testing.T) {
 			t.Error(err)
 			return
 		}
-		dialer, err := DialWebsocket(context.Background(), connectAddr, nil, nil)
+
+		dialer, err := DialWebsocket(context.Background(), connectAddr, &DialOptions{
+			Log: &log,
+		}, nil)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Adds optional debug logging to Dial

```
$ CODER_TUNNEL_DEBUG=true go run ./cmd/coder tunnel dean-c 8081 8081
2021-07-24 06:34:31.617 [INFO]  <tunnel.go:39>  debug logging enabled
2021-07-24 06:34:34.346 [DEBUG] <tunnel.go:110> Connecting to workspace...
2021-07-24 06:34:34.346 [DEBUG] (wsnet) <dial.go:57>    connecting to broker    {"broker": "wss://master.cdr.dev/api/private/envagent/xxx/connect?session_token=xxx"}
2021-07-24 06:34:34.927 [DEBUG] (wsnet) <dial.go:68>    connected to broker
2021-07-24 06:34:34.927 [DEBUG] (wsnet) <dial.go:101>   creating peer connection        {"options": "\u0026{Log:0xc0003c22a0 ICEServers:[{URLs:[turn:127.0.0.1:3478?transport=tcp] Username:~magicalusername~ Credential:~magicalusername~ CredentialType:password}] TURNProxyAuthToken:xxx TURNProxyURL:https://master.cdr.dev}", "turn_proxy": "\u0026{baseURL:xxx token:xxx}"}
2021-07-24 06:34:34.929 [DEBUG] (wsnet) <dial.go:106>   created peer connection
2021-07-24 06:34:34.929 [DEBUG] (wsnet) <dial.go:113>   creating control channel        {"proto": "control"}
2021-07-24 06:34:34.930 [DEBUG] (wsnet) <dial.go:126>   created offer   {"offer": {"type": "offer", "sdp": "xxx"}}
2021-07-24 06:34:34.930 [DEBUG] (wsnet) <dial.go:142>   sending offer message   {"msg": {"offer": {"type": "offer", "sdp": "xxx"}, "servers": [{"urls": ["turn:127.0.0.1:3478?transport=tcp"], "username": "~magicalusername~", "credential": "~magicalusername~"}], "turn_proxy_url": "https://master.cdr.dev", "ports": null, "error": "", "answer": null, "candidate": ""}}
2021-07-24 06:34:34.932 [DEBUG] (wsnet) <dial.go:221>   beginning negotiation
2021-07-24 06:34:35.308 [DEBUG] (wsnet) <dial.go:231>   got message from handshake conn {"msg": {"offer": null, "servers": null, "turn_proxy_url": "", "ports": null, "error": "", "answer": {"type": "answer", "sdp": "xxx"}, "candidate": ""}}
2021-07-24 06:34:35.308 [DEBUG] (wsnet) <dial.go:251>   received answer {"a": {"type": "answer", "sdp": "xxx"}}
2021-07-24 06:34:36.261 [DEBUG] (wsnet) <dial.go:231>   got message from handshake conn {"msg": {"offer": null, "servers": null, "turn_proxy_url": "", "ports": null, "error": "", "answer": null, "candidate": "xxx"}}
2021-07-24 06:34:36.262 [DEBUG] (wsnet) <dial.go:242>   adding remote ICE candidate     {"c": {"candidate": "xxx", "sdpMid": null, "sdpMLineIndex": null, "usernameFragment": null}}
2021-07-24 06:34:38.121 [DEBUG] (wsnet) <dial.go:344>   opening data channel    {"proto": "tcp:localhost:8081"}
2021-07-24 06:34:38.678 [DEBUG] (wsnet) <dial.go:363>   data channel opened     {"proto": "tcp:localhost:8081", "dc_id": 3}
2021-07-24 06:34:38.678 [DEBUG] (wsnet) <dial.go:369>   data channel detached   {"proto": "tcp:localhost:8081", "dc_id": 3}
2021-07-24 06:34:39.050 [DEBUG] (wsnet) <dial.go:382>   dial response   {"proto": "tcp:localhost:8081", "dc_id": 3, "res": "{Code:dial_error Err:dial tcp 127.0.0.1:8081: connect: connection refused Net:tcp Op:dial}"}
fatal: running tunnel: dial tcp: dial tcp 127.0.0.1:8081: connect: connection refused

exit status 1
```

[CH-15414]