### PR TITLE
chore: update build settings for coder-cli

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,44 +1,75 @@
 name: build
-on: [push]
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.3'
+          go-version: '^1.16.7'
+
       - name: Build
         run: make -j build/linux build/windows
+
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
           name: coder-cli
           path: ./ci/bin/coder-cli-*
+
   build_darwin:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.3'
+          go-version: '^1.16.7'
+
       - name: Install Gon
         run: |
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
+
       - name: Import Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v1
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+
       - name: Build
         run: make build/macos
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+
       - name: Upload
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v2
         with:
@@ -48,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,6 +35,8 @@ jobs:
       CODER_PASSWORD: ${{ secrets.CODER_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,8 +1,30 @@
 name: integration
+
 on:
   push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
   schedule:
-    - cron:  '*/180 * * * *'
+    - cron: '*/180 * * * *'
+
+  workflow_dispatch:
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
 
 jobs:
   integration:
@@ -12,15 +34,18 @@ jobs:
       CODER_EMAIL: ${{ secrets.CODER_EMAIL }}
       CODER_PASSWORD: ${{ secrets.CODER_PASSWORD }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14'
+          go-version: '^1.16.7'
+
       - name: integration tests
         run: ./ci/scripts/integration.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v2
         with:
@@ -49,6 +51,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install Gon
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,21 @@
+name: create_github_release
+
 on:
   create:
     tags: "v*"
-name: create_github_release
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build:
     name: Build binaries
@@ -9,49 +23,60 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.3'
+          go-version: '^1.16.7'
+
       - name: Build
         run: make -j build/linux build/windows
+
       - name: Upload linux
         uses: actions/upload-artifact@v2
         with:
           name: coder-cli-linux-amd64
           path: ./ci/bin/coder-cli-linux-amd64.tar.gz
+
       - name: Upload windows
         uses: actions/upload-artifact@v2
         with:
           name: coder-cli-windows
           path: ./ci/bin/coder-cli-windows.zip
+
   build_darwin:
     name: Build darwin binary
     runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install Gon
         run: |
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
+
       - name: Import Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v1
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.3'
+          go-version: '^1.16.7'
+
       - name: Build Release Assets
         run: make build/macos
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+
       - name: Upload darwin
         uses: actions/upload-artifact@v2
         with:
           name: coder-cli-darwin-amd64
           path: ./ci/bin/coder-cli-darwin-amd64.zip
+
   draft_release:
     name: Create Release
     runs-on: ubuntu-20.04
@@ -60,8 +85,10 @@ jobs:
       - build
     steps:
       - uses: actions/download-artifact@v2
+
       - name: content
         run: sh -c "ls -al"
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -73,6 +100,7 @@ jobs:
           body: ""
           draft: true
           prerelease: false
+
       - name: Upload Linux Release
         id: upload-linux-release-asset
         uses: actions/upload-release-asset@v1
@@ -83,6 +111,7 @@ jobs:
           asset_path: coder-cli-linux-amd64/coder-cli-linux-amd64.tar.gz
           asset_name: coder-cli-linux-amd64.tar.gz
           asset_content_type: application/tar+gzip
+
       - name: Upload MacOS Release
         id: upload-macos-release-asset
         uses: actions/upload-release-asset@v1
@@ -93,6 +122,7 @@ jobs:
           asset_path: coder-cli-darwin-amd64/coder-cli-darwin-amd64.zip
           asset_name: coder-cli-darwin-amd64.zip
           asset_content_type: application/zip
+
       - name: Upload Windows Release
         id: upload-windows-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,27 @@
 name: test
-on: [push]
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
 
 jobs:
   fmt:


### PR DESCRIPTION
* Update actions/checkout from v1 to v2
* Configure build to run on pushes/pull requests on main
* Add restrictive workflow permissions
* Update minimum setup-go from 1.16.3 to 1.16.7
* Enable workflow dispatch for all builds