### PR TITLE
fix: rename envs to workspaces

### DIFF
--- a/coder-sdk/workspace.go
+++ b/coder-sdk/workspace.go
@@ -112,7 +112,7 @@ type ParseTemplateRequest struct {
 	Local    io.Reader `json:"-"`
 }
 
-// TemplateVersion is a Workspaces As Code (WAC) template.
+// TemplateVersion is a workspace template.
 // For now, let's not interpret it on the CLI level. We just need
 // to forward this as part of the create workspace request.
 type TemplateVersion struct {

--- a/docs/coder_workspaces_create-from-config.md
+++ b/docs/coder_workspaces_create-from-config.md
@@ -4,7 +4,7 @@ create a new workspace from a template
 
 ### Synopsis
 
-Create a new Coder workspace using a Workspaces As Code template.
+Create a new Coder workspace using a workspace template.
 
 ```
 coder workspaces create-from-config [flags]
@@ -14,8 +14,8 @@ coder workspaces create-from-config [flags]
 
 ```
 # create a new workspace from git repository
-coder envs create-from-config --name="dev-env" --repo-url https://github.com/cdr/m --ref my-branch
-coder envs create-from-config --name="dev-env" -f coder.yaml
+coder workspaces create-from-config --name="dev-env" --repo-url https://github.com/cdr/m --ref my-branch
+coder workspaces create-from-config --name="dev-env" --filepath coder.yaml
 ```
 
 ### Options

--- a/docs/coder_workspaces_edit-from-config.md
+++ b/docs/coder_workspaces_edit-from-config.md
@@ -4,7 +4,7 @@ change the template a workspace is tracking
 
 ### Synopsis
 
-Edit an existing Coder workspace using a Workspaces As Code template.
+Edit an existing Coder workspace using a workspace template.
 
 ```
 coder workspaces edit-from-config [flags]
@@ -14,8 +14,8 @@ coder workspaces edit-from-config [flags]
 
 ```
 # edit a new workspace from git repository
-coder envs edit-from-config dev-env --repo-url https://github.com/cdr/m --ref my-branch
-coder envs edit-from-config dev-env -f coder.yaml
+coder workspaces edit-from-config dev-env --repo-url https://github.com/cdr/m --ref my-branch
+coder workspaces edit-from-config dev-env --filepath coder.yaml
 ```
 
 ### Options


### PR DESCRIPTION
Fix a few stray uses of the legacy "environments" terminology (envs)
and replace it with "workspaces."