### PR TITLE
feat: write agent output to a temporary file

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -61,6 +61,9 @@ coder agent start --coder-url https://my-coder.com --token xxxx-xxxx
 			}
 
 			log := slog.Make(sinks...).Leveled(slog.LevelDebug)
+			if err != nil {
+				log.Info(ctx, "failed to open agent log file", slog.Error(err))
+			}
 			if coderURL == "" {
 				var ok bool
 				coderURL, ok = os.LookupEnv("CODER_URL")

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -11,7 +11,6 @@ import (
 	// from structured logging.
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
-	"cdr.dev/slog/sloggers/slogjson"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
@@ -57,7 +56,7 @@ coder agent start --coder-url https://my-coder.com --token xxxx-xxxx
 
 			file, err := os.OpenFile(filepath.Join(os.TempDir(), "coder-agent.log"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 			if err == nil && file != nil {
-				sinks = append(sinks, slogjson.Sink(file))
+				sinks = append(sinks, sloghuman.Sink(file))
 			}
 
 			log := slog.Make(sinks...).Leveled(slog.LevelDebug)


### PR DESCRIPTION
## How I tested this

Running the agent, the log data is written to a file as well (and truncated/re-created on subsequent starts):

```shell-session
$ go run ./cmd/coder/main.go agent start
2021-09-02 01:36:32.847 [INFO]  <agent.go:90>   starting wsnet listener {"coder_access_url": "https://master.cdr.dev"}
2021-09-02 01:36:32.848 [INFO]  <listen.go:114> connecting to broker    {"broker_url": "wss://master.cdr.dev/api/private/envagent/listen?service_token=xxx"}
2021-09-02 01:36:32.928 [INFO]  <listen.go:136> broker connection established
^C2021-09-02 01:36:53.420 [INFO]        <agent.go:96>   closing wsnet listener
2021-09-02 01:36:53.421 [INFO]  <listen.go:451> listener closed

$ cat /tmp/coder-agent.log 
2021-09-02 15:22:25.006 [INFO]  <agent.go:92>   starting wsnet listener {"coder_access_url": "https://master.cdr.dev"}
2021-09-02 15:22:25.007 [INFO]  <listen.go:114> connecting to broker    {"broker_url": "wss://master.cdr.dev/api/private/envagent/listen?service_token=xxx"}
2021-09-02 15:22:25.098 [INFO]  <listen.go:136> broker connection established
2021-09-02 15:22:26.690 [INFO]  <agent.go:98>   closing wsnet listener
2021-09-02 15:22:26.690 [INFO]  <listen.go:451> listener closed
```

If there's a permission error preventing the file frmo being truncated, a log message will be output to stderr (simulated by chowning the file to root):

```shell-session
$ sudo chown root:root /tmp/coder-agent.log 
$ go run ./cmd/coder/main.go agent start
2021-09-02 01:41:21.363 [INFO]  <agent.go:65>   failed to open agent log file   {"error": "open /tmp/coder-agent.log: permission denied"}
2021-09-02 01:41:21.365 [INFO]  <agent.go:93>   starting wsnet listener {"coder_access_url": "https://master.cdr.dev"}
2021-09-02 01:41:21.365 [INFO]  <listen.go:114> connecting to broker    {"broker_url": "wss://master.cdr.dev/api/private/envagent/listen?service_token=xxx"}
2021-09-02 01:41:21.478 [INFO]  <listen.go:136> broker connection established
^C2021-09-02 01:41:23.116 [INFO]        <agent.go:99>   closing wsnet listener
2021-09-02 01:41:23.116 [INFO]  <listen.go:451> listener closed
```