### PR TITLE
feat: make log file path optional and configurable

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -63,7 +63,7 @@ coder agent start --log-file=/tmp/coder-agent.log
 				if err != nil {
 					// If an error occurs, it should be fatal, because we asked to write
 					// a log to a path but cannot write it for some reason
-					return xerrors.Errorf("open log-file %q: %w", logFile, err)
+					return xerrors.Errorf("open log file: %w", err)
 				}
 
 				sinks = append(sinks, sloghuman.Sink(file))


### PR DESCRIPTION
New help output:

```shell-session
$ go run ./cmd/coder/main.go agent start --help
starts the coder agent

Usage:
  coder agent start --coder-url=<coder_url> --token=<token> --log-file=<path> [flags]

Examples:
# start the agent and use CODER_URL and CODER_AGENT_TOKEN env vars
coder agent start

# start the agent and connect with a specified url and agent token
coder agent start --coder-url https://my-coder.com --token xxxx-xxxx

# start the agent and write a copy of the log to /tmp/coder-agent.log
# if the file already exists, it will be truncated
coder agent start --log-file=/tmp/coder-agent.log


Flags:
      --coder-url string   coder access url
  -h, --help               help for start
      --log-file string    write a copy of logs to file
      --token string       coder agent token

Global Flags:
  -v, --verbose   show verbose output
```

Log to file:

```shell-session
$ go run ./cmd/coder/main.go agent start --log-file=/tmp/file.log
2021-09-02 19:23:22.255 [INFO]  <agent.go:100>  starting wsnet listener {"coder_access_url": "https://master.cdr.dev"}
2021-09-02 19:23:22.256 [INFO]  <listen.go:114> connecting to broker    {"broker_url": "wss://master.cdr.dev/api/private/envagent/listen?service_token=6067852b-35c4615f433d6b14ede7d1cb"}
2021-09-02 19:23:22.343 [INFO]  <listen.go:136> broker connection established
^C2021-09-02 19:23:23.100 [INFO]        <agent.go:106>  closing wsnet listener
2021-09-02 19:23:23.101 [INFO]  <listen.go:451> listener closed
$ cat /tmp/file.log
2021-09-02 19:23:22.255 [INFO]  <agent.go:100>  starting wsnet listener {"coder_access_url": "https://master.cdr.dev"}
2021-09-02 19:23:22.256 [INFO]  <listen.go:114> connecting to broker    {"broker_url": "wss://master.cdr.dev/api/private/envagent/listen?service_token=6067852b-35c4615f433d6b14ede7d1cb"}
2021-09-02 19:23:22.343 [INFO]  <listen.go:136> broker connection established
2021-09-02 19:23:23.100 [INFO]  <agent.go:106>  closing wsnet listener
2021-09-02 19:23:23.101 [INFO]  <listen.go:451> listener closed
```

Permission error:

```shell-session
$  go run ./cmd/coder/main.go agent start --log-file=/tmp/agent.log
2021-09-02 19:23:39.338 [WARN]  <agent.go:64>   failed to open log file {"error": "open /tmp/agent.log: permission denied"}
2021-09-02 19:23:39.339 [INFO]  <agent.go:100>  starting wsnet listener {"coder_access_url": "https://master.cdr.dev"}
2021-09-02 19:23:39.339 [INFO]  <listen.go:114> connecting to broker    {"broker_url": "wss://master.cdr.dev/api/private/envagent/listen?service_token=6067852b-35c4615f433d6b14ede7d1cb"}
2021-09-02 19:23:39.423 [INFO]  <listen.go:136> broker connection established
^C2021-09-02 19:23:40.226 [INFO]        <agent.go:106>  closing wsnet listener
2021-09-02 19:23:40.226 [INFO]  <listen.go:451> listener closed

exit status 1
```

Default behavior (no log):

```shell-session
$ go run ./cmd/coder/main.go agent start 
2021-09-02 19:24:39.147 [INFO]  <agent.go:100>  starting wsnet listener {"coder_access_url": "https://master.cdr.dev"}
2021-09-02 19:24:39.148 [INFO]  <listen.go:114> connecting to broker    {"broker_url": "wss://master.cdr.dev/api/private/envagent/listen?service_token=6067852b-35c4615f433d6b14ede7d1cb"}
2021-09-02 19:24:39.231 [INFO]  <listen.go:136> broker connection established
^C2021-09-02 19:24:40.906 [INFO]        <agent.go:106>  closing wsnet listener
```