### PR TITLE
feat: Allow making a workspace for another user as an admin

### DIFF
--- a/coder-sdk/workspace.go
+++ b/coder-sdk/workspace.go
@@ -89,6 +89,10 @@ type CreateWorkspaceRequest struct {
 	Namespace       string  `json:"namespace"`
 	EnableAutoStart bool    `json:"autostart_enabled"`
 
+	// ForUserID is an optional param to create a workspace for another user
+	// other than the requester. This only works for admins and site managers.
+	ForUserID string `json:"for_user_id,omitempty"`
+
 	// TemplateID comes from the parse template route on cemanager.
 	TemplateID string `json:"template_id,omitempty"`
 }

--- a/docs/coder_workspaces_create.md
+++ b/docs/coder_workspaces_create.md
@@ -33,6 +33,7 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
   -o, --org string           name of the organization the workspace should be created under.
       --provider string      name of Workspace Provider with which to create the workspace
   -t, --tag string           tag of the image the workspace will be based off of. (default "latest")
+      --user string          Specify the user whose resources to target (default "me")
 ```
 
 ### Options inherited from parent commands

--- a/docs/coder_workspaces_create.md
+++ b/docs/coder_workspaces_create.md
@@ -33,7 +33,7 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
   -o, --org string           name of the organization the workspace should be created under.
       --provider string      name of Workspace Provider with which to create the workspace
   -t, --tag string           tag of the image the workspace will be based off of. (default "latest")
-      --user string          Specify the user whose resources to target (default "me")
+      --user string          Specify the user whose resources to target. This flag can only be used by admins and managers. Input an email or user id. (default "me")
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/workspaces.go
+++ b/internal/cmd/workspaces.go
@@ -449,6 +449,7 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 				}
 			}
 
+			var forEmail string
 			if forUser != "" && forUser != coder.Me {
 				// Making a workspace for another user, do they exist?
 				u, err := client.UserByEmail(ctx, forUser)
@@ -460,6 +461,7 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 					}
 				}
 				forUser = u.ID
+				forEmail = u.Email
 			}
 
 			// ExactArgs(1) ensures our name value can't panic on an out of bounds.
@@ -504,9 +506,13 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 				return nil
 			}
 
+			extraFlags := ""
+			if forEmail != coder.Me && forEmail != "" {
+				extraFlags = " --user " + forEmail
+			}
 			clog.LogSuccess("creating workspace...",
 				clog.BlankLine,
-				clog.Tipf(`run "coder workspaces watch-build %s" to trail the build logs`, workspace.Name),
+				clog.Tipf(`run "coder workspaces watch-build %s%s" to trail the build logs`, workspace.Name, extraFlags),
 			)
 			return nil
 		},

--- a/internal/cmd/workspaces.go
+++ b/internal/cmd/workspaces.go
@@ -449,7 +449,7 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 				}
 			}
 
-			if forUser != "" {
+			if forUser != "" && forUser != coder.Me {
 				// Making a workspace for another user, do they exist?
 				u, err := client.UserByEmail(ctx, forUser)
 				if err != nil {
@@ -522,7 +522,7 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 	cmd.Flags().BoolVar(&follow, "follow", false, "follow buildlog after initiating rebuild")
 	cmd.Flags().BoolVar(&useCVM, "container-based-vm", false, "deploy the workspace as a Container-based VM")
 	cmd.Flags().BoolVar(&enableAutostart, "enable-autostart", false, "automatically start this workspace at your preferred time.")
-	cmd.Flags().StringVar(&forUser, "for", "", "Optionally create a workspace for another user. This field should be the user's email.")
+	cmd.Flags().StringVar(&forUser, "user", coder.Me, "Specify the user whose resources to target")
 	_ = cmd.MarkFlagRequired("image")
 	return cmd
 }

--- a/internal/cmd/workspaces.go
+++ b/internal/cmd/workspaces.go
@@ -462,6 +462,8 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 				}
 				forUser = u.ID
 				forEmail = u.Email
+			} else if forUser == coder.Me {
+				forUser = "" // coder.Me means it's not for someone else, set blank
 			}
 
 			// ExactArgs(1) ensures our name value can't panic on an out of bounds.

--- a/internal/cmd/workspaces.go
+++ b/internal/cmd/workspaces.go
@@ -528,7 +528,7 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 	cmd.Flags().BoolVar(&follow, "follow", false, "follow buildlog after initiating rebuild")
 	cmd.Flags().BoolVar(&useCVM, "container-based-vm", false, "deploy the workspace as a Container-based VM")
 	cmd.Flags().BoolVar(&enableAutostart, "enable-autostart", false, "automatically start this workspace at your preferred time.")
-	cmd.Flags().StringVar(&forUser, "user", coder.Me, "Specify the user whose resources to target")
+	cmd.Flags().StringVar(&forUser, "user", coder.Me, "Specify the user whose resources to target. This flag can only be used by admins and managers. Input an email or user id.")
 	_ = cmd.MarkFlagRequired("image")
 	return cmd
 }


### PR DESCRIPTION
# What this does

Adds a `--user` on creating a workspace for another user. Must be an admin/manager to do this.

# Admin flow

Create a workspace for a user
```
coder workspaces create test --cpu 1 --disk 1 --memory 1 --image ubuntu --user steven@gmail.com
```

Watch it build
```
coder workspaces watch-build base-img --user steven@gmail.com
```

View the workspace
```
coder workspaces ls --user steven@gmail.com 
```

Delete the workspace
```
coder workspaces rm --user steven@gmail.com test
```