### PR TITLE
fixup! feat: Add update command to coder-cli (#417)

### DIFF
--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -258,7 +258,7 @@ func getDesiredVersion(httpClient getter, coderURLArg string, versionArg string)
 	}
 
 	if versionArg != "" {
-		desiredVersion, err = semver.StrictNewVersion(versionArg)
+		desiredVersion, err = semver.NewVersion(versionArg)
 		if err != nil {
 			return &semver.Version{}, xerrors.Errorf("parse desired version arg: %w", err)
 		}


### PR DESCRIPTION
* Use `semver.NewVersion` instead of `semver.StrictNewVersion` as otherwise users must type the explicit trailing zeros e.g. `coder update --version 1.21.0` instead of `coder update --version 1.21`.